### PR TITLE
Clarify id parameter of getCoverArt

### DIFF
--- a/content/en/docs/Endpoints/getcoverart.md
+++ b/content/en/docs/Endpoints/getcoverart.md
@@ -15,7 +15,7 @@ Returns a cover art image.
 
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
-| `id` | **Yes** |     | The ID of a song, album or artist. |
+| `id` | **Yes** |     | The coverArt ID. Returned by most entities likes [`Child`](../../responses/child) or [`AlbumID3`](../../responses/albumid3) |
 | `size` | No  |     | If specified, scale image to this size. |
 
 ### Example


### PR DESCRIPTION
The id parameter is not the id of the media, it's the covertArt ID, a value that is returned by many endpoints via the covertArt property.