### PR TITLE
Update BPM default value

### DIFF
--- a/content/en/docs/Responses/Child.md
+++ b/content/en/docs/Responses/Child.md
@@ -179,7 +179,7 @@ description: >
 | `originalWidth` | `int` | No |     | The video original Width |
 | `originalHeight` | `int` | No |     | The video original Height |
 | `played` | `string` | No | **Yes**    | Date the album was last played. [ISO 8601]|
-| `bpm` | `int` | No |   **Yes**   | The BPM of the song. |
+| `bpm` | `int` | No |   **Yes**   | The BPM of the song. The default value when the tag is not present should be -1. |
 | `comment` | `string` | No |  **Yes**    | The comment tag of the song. |
 | `sortName` | `string` | No |  **Yes**   | The song sort name. |
 | `musicBrainzId` | `string` | No |  **Yes**   | The track MusicBrainzID. |


### PR DESCRIPTION
To help distinguish between a BPM tag of 0, define the missing value default as -1.