### PR TITLE
Update originalReleaseDate field to new ItemDate type

### DIFF
--- a/content/en/docs/Responses/AlbumID3.md
+++ b/content/en/docs/Responses/AlbumID3.md
@@ -59,7 +59,11 @@ description: >
         "cool"
     ],
     "sortName": "lagerfeuer (8-bit)",
-    "originalReleaseDate": "2001-03-10T02:19:35.784818075Z",
+    "originalReleaseDate": {
+        "year": 2001,
+        "month": 3,
+        "day": 10
+    },
     "isCompilation": false,
     "discTitles": [
         {
@@ -115,7 +119,7 @@ description: >
 | `releaseTypes` | Array of `string` | No | **Yes**    | The types of this album release. (Album, Compilation, EP, Remix, ...).|
 | `moods` | Array of `string` | No | **Yes**    | The list of all moods of the album. |
 | `sortName` | `string` | No |  **Yes**   | The album sort name. |
-| `originalReleaseDate` | `string` | No |   **Yes**   | Date the album was originally released. [ISO 8601]|
+| `originalReleaseDate` | [`ItemDate`](../itemdate) | No |   **Yes**   | Date the album was originally released. |
 | `isCompilation` | `boolean` | No |  **Yes**    | True if the album is a compilation. |
 | `discTitles` | Array of [`DiscTitle`](../disctitle) | No | **Yes**    | The list of all disc titles of the album. |
 

--- a/content/en/docs/Responses/AlbumID3WithSongs.md
+++ b/content/en/docs/Responses/AlbumID3WithSongs.md
@@ -59,7 +59,11 @@ description: >
         "cool"
     ],
     "sortName": "lagerfeuer (8-bit)",
-    "originalReleaseDate": "2001-03-10T02:19:35.784818075Z",
+    "originalReleaseDate": {
+        "year": 2001,
+        "month": 3,
+        "day": 10
+    },
     "isCompilation": false,
     "discTitles": [
         {
@@ -214,7 +218,7 @@ description: >
 | `releaseTypes` | Array of `string` | No | **Yes**    | The types of this album release. (Album, Compilation, EP, Remix, ...).|
 | `moods` | Array of `string` | No | **Yes**    | The list of all moods of the album. |
 | `sortName` | `string` | No |  **Yes**   | The album sort name. |
-| `originalReleaseDate` | `string` | No |   **Yes**   | Date the album was originally released. [ISO 8601]|
+| `originalReleaseDate` | [`ItemDate`](../itemdate) | No |   **Yes**   | Date the album was originally released. |
 | `isCompilation` | `boolean` | No |  **Yes**    | True if the album is a compilation.|
 | `discTitles` | Array of [`DiscTitle`](../disctitle) | No | **Yes**    | The list of all disc titles of the album. |
 | `song` | Array of [`Child`](../child) | No |     | The list of songs |

--- a/content/en/docs/Responses/itemDate.md
+++ b/content/en/docs/Responses/itemDate.md
@@ -1,0 +1,43 @@
+---
+title: "ItemDate"
+linkTitle: "ItemDate [OS]"
+description: >
+  A date for a media item that may be just a year, or year-month, or full date.
+---
+
+{{< tabpane persistLang=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic" lang="json">}}
+{
+  "year": 2020
+  "month": 01
+  "day": 01
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic" lang="xml">}}
+  <!-- XML name is the name of the property on the parent object-->
+  <originalReleaseDate year="2020" month="01" day="01"/>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+| Field |  Type | Req. | OpenS. | Details |
+| --- | --- | --- | --- | --- |
+| `year`  | `integer` | **Yes** |  **Yes**   | The year |
+| `month` | `integer` | No      |  **Yes**   | The month (1-12) |
+| `day`   | `integer` | No      |  **Yes**   | The day (1-31) |
+
+{{< alert color="warning" title="OpenSubsonic" >}}
+This is a new OpenSubsonic response type.
+{{< /alert >}}
+
+---
+
+{{< alert color="warning" title="OpenSubsonic server support" >}}
+
+| Server | Min vers. | Comment |
+| --- | --- | --- |
+
+{{< /alert >}}

--- a/content/en/docs/Responses/itemDate.md
+++ b/content/en/docs/Responses/itemDate.md
@@ -7,16 +7,16 @@ description: >
 
 {{< tabpane persistLang=false >}}
 {{< tab header="**Example**:" disabled=true />}}
-{{< tab header="OpenSubsonic" lang="json">}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
 {
-  "year": 2020
-  "month": 01
-  "day": 01
+  "year": 2020,
+  "month": 1,
+  "day": 1
 }
 {{< /tab >}}
-{{< tab header="OpenSubsonic" lang="xml">}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
   <!-- XML name is the name of the property on the parent object-->
-  <originalReleaseDate year="2020" month="01" day="01"/>
+  <originalReleaseDate year="2020" month="1" day="1"/>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
 Does not exist.

--- a/content/en/docs/Responses/itemDate.md
+++ b/content/en/docs/Responses/itemDate.md
@@ -25,7 +25,7 @@ Does not exist.
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
-| `year`  | `integer` | **Yes** |  **Yes**   | The year |
+| `year`  | `integer` | No      |  **Yes**   | The year |
 | `month` | `integer` | No      |  **Yes**   | The month (1-12) |
 | `day`   | `integer` | No      |  **Yes**   | The day (1-31) |
 


### PR DESCRIPTION
**NOTE: this is a breaking change** but as of now, LMS (server) and Symfonium (client) are the only users of this field, and they have coordinated the ability to make the change.

This is needed because the original type of the field was an ISO date which *does not* allow the representation of "partial" dates (ie only year known, or year and month), which is a common scenario with music file tags.