### PR TITLE
Add Nextcloud Music as a participating server

### DIFF
--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -193,4 +193,5 @@ A [`subsonic-response`](../../responses/subsonic-response) with a nested [`searc
 | **Funkwhale** | 1.2.8 | Support not passing a query parameter. |
 | **Astiga** |  | Support `query=` |
 | **LMS** | 3.35.1 | Support `query=` |
+| **Nextcloud Music / ownCloud Music** | 1.10.0 | Support `query=` |
 {{< /alert >}}

--- a/content/en/docs/Responses/Subsonic-response.md
+++ b/content/en/docs/Responses/Subsonic-response.md
@@ -59,4 +59,5 @@ New fields are added:
 | **Funkwhale** |  |  Support `type`, version is exposed as `funkwhaleVersion` |
 | **Astiga** |  | Expose `Astiga/production` in `serverVersion` |
 | **LMS** |  | Support `type` |
+| **Nextcloud Music / ownCloud Music** | 1.10.0 | Support `openSubsonic`, `type`, and `serverVersion` |
 {{< /alert >}}

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -33,6 +33,7 @@ Any server or client can join the organization and make proposals [OpenSubsonic]
 - [Gonic](https://github.com/sentriz/gonic)
 - [LMS - Lightweight Music Server](https://github.com/epoupon/lms)
 - [Navidrome](https://www.navidrome.org/)
+- [Nextcloud Music / ownCloud Music](https://github.com/owncloud/music)
 - [Supysonic](https://github.com/spl0k/supysonic)
 
 ### Clients


### PR DESCRIPTION
The Nextcloud Music app has a rudimentary support for the ~~OpenAmpache~~ OpenSubsonic API extensions starting from the version 1.10.0 (released today 2024-01-27).

The same application may be called also ownCloud Music, depending on the host cloud used.