### PR TITLE
Update support status for Nextcloud Music

### DIFF
--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -120,3 +120,12 @@ Does not exist.
 | Field        | Type                          | Req.    | OpenS.  | Details                   |
 | ------------ | ----------------------------- | ------- | ------- | ------------------------- |
 | `lyricsList` | [`lyricsList`](../../responses/lyricslist) | **Yes** | **Yes** | List of structured lyrics |
+
+---
+
+{{< alert color="warning" title="OpenSubsonic server support" >}}
+
+| Server | Min vers. | Comment |
+| --- | --- | --- |
+| **Nextcloud Music / ownCloud Music** | 2.0.0 |  |
+{{< /alert >}}

--- a/content/en/docs/Endpoints/getopensubsonicextensions.md
+++ b/content/en/docs/Endpoints/getopensubsonicextensions.md
@@ -72,4 +72,5 @@ This is a new endpoint.
 
 | Server | Min vers. | Comment |
 | --- | --- | --- |
+| **Nextcloud Music / ownCloud Music** | 1.11.0 |  |
 {{< /alert >}}

--- a/content/en/docs/Responses/AlbumID3.md
+++ b/content/en/docs/Responses/AlbumID3.md
@@ -158,4 +158,5 @@ New fields are added:
 | Server | Min vers. | Comment |
 | --- | --- | --- |
 | **Navidrome** |  | Support `played` and `userRating` |
+| **Nextcloud Music / ownCloud Music** | 2.0.0 | Support `sortName` and `userRating` |
 {{< /alert >}}

--- a/content/en/docs/Responses/AlbumID3WithSongs.md
+++ b/content/en/docs/Responses/AlbumID3WithSongs.md
@@ -267,5 +267,6 @@ New fields are added:
 
 | Server | Min vers. | Comment |
 | --- | --- | --- |
+| **Nextcloud Music / ownCloud Music** | 2.0.0 | Support `sortName` and `userRating` |
 
 {{< /alert >}}

--- a/content/en/docs/Responses/ArtistID3.md
+++ b/content/en/docs/Responses/ArtistID3.md
@@ -70,4 +70,5 @@ New fields are added:
 
 | Server | Min vers. | Comment |
 | --- | --- | --- |
+| **Nextcloud Music / ownCloud Music** | 2.0.0 | Support `sortName` |
 {{< /alert >}}

--- a/content/en/docs/Responses/Child.md
+++ b/content/en/docs/Responses/Child.md
@@ -232,4 +232,5 @@ New fields are added:
 | Server | Min vers. | Comment |
 | --- | --- | --- |
 | **Navidrome** | 0.49.0 | Support `played`|
+| **Nextcloud Music / ownCloud Music** | 2.0.0 | Support `played` and `sortName` |
 {{< /alert >}}


### PR DESCRIPTION
Nextcloud Music v2.0.0 brought support for the endpoint `getLyricsBySongId`. For anyone wishing to test this, note that NC Music reads the lyrics only from the file metadata tags. The language information is not parsed but returned always as "xxx" in this API. The `offset` is returned always as "0" because NC Music already internally calculates the offset-adjusted timestamps and returns these for each line.

In addition to this new endpoint, NC Music v2.0.0 added a few simple properties defined in the OpenSubsonic API to a few responses.

Support for the endpoint `getOpenSubsonicExtensions` was added already in the previous release v1.11.0.
