### PR TITLE
Add contributors to albumid3

### DIFF
--- a/content/en/docs/Responses/AlbumID3.md
+++ b/content/en/docs/Responses/AlbumID3.md
@@ -80,6 +80,15 @@ description: >
             "disc": 2,
             "title": "Disc 1 title"
         }
+    ],
+    "contributors": [
+        {
+            "role": "composer",
+            "artist": {
+                "id": "ar-3",
+                "name": "Artist 3"
+            }
+        }
     ]
 }
 {{< /tab >}}
@@ -130,6 +139,8 @@ description: >
 | `isCompilation` | `boolean` | No |  **Yes**    | True if the album is a compilation. |
 | `explicitStatus` | `string` | No |  **Yes**    | Returns "explicit" if at least one song is explicit, "clean" if no song is explicit and at least one is "clean" else "". |
 | `discTitles` | Array of [`DiscTitle`](../disctitle) | No | **Yes**    | The list of all disc titles of the album. |
+| `contributors` | Array of [`Contributor`](../contributor) | No | **Yes**  | The list of all contributor artists of the album. |
+
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 New fields are added:
@@ -148,6 +159,7 @@ New fields are added:
 - `isCompilation`
 - `discTitles`
 - `explicitStatus`
+- `contributors`
 
 **Note**: All OpenSubsonic added fields are **optionals**. But if a server support a field it **must** return it with an empty / default value when not present in it's database so that clients knows what the server supports.
 

--- a/content/en/docs/Responses/AlbumID3WithSongs.md
+++ b/content/en/docs/Responses/AlbumID3WithSongs.md
@@ -81,6 +81,15 @@ description: >
       "title": "Disc 1 title"
     }
   ],
+  "contributors": [
+    {
+      "role": "composer",
+      "artist": {
+        "id": "ar-3",
+        "name": "Artist 3"
+      }
+    }
+  ],
   "song": [
     {
       "id": "300000116",
@@ -243,6 +252,7 @@ description: >
 | `isCompilation` | `boolean` | No |  **Yes**    | True if the album is a compilation.|
 | `explicitStatus` | `string` | No |  **Yes**    | Returns "explicit" if at least one song is explicit, "clean" if no song is explicit and at least one is "clean" else "". |
 | `discTitles` | Array of [`DiscTitle`](../disctitle) | No | **Yes**    | The list of all disc titles of the album. |
+| `contributors` | Array of [`Contributor`](../contributor) | No | **Yes**  | The list of all contributor artists of the album. |
 | `song` | Array of [`Child`](../child) | No |     | The list of songs |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
@@ -262,6 +272,7 @@ New fields are added:
 - `isCompilation`
 - `discTitles`
 - `explicitStatus`
+- `contributors`
 
 **Note**: All OpenSubsonic added fields are **optionals**. But if a server support a field it **must** return it with an empty / default value when not present in it's database so that clients knows what the server supports.
 


### PR DESCRIPTION
The definition of a contributor of an album can be server-specific (or just empty), but useful for lists.