### PR TITLE
Add OpenAPI json file

### DIFF
--- a/static/openapi.json
+++ b/static/openapi.json
@@ -8643,9 +8643,9 @@
                         "properties": {
                             "status": {
                                 "type": "string",
-                                "description": "The status of the request. [Ex: success]",
+                                "description": "The command result. `ok`",
                                 "enum": [
-                                    "success"
+                                    "ok"
                                 ]
                             }
                         },
@@ -8676,7 +8676,7 @@
                         "properties": {
                             "status": {
                                 "type": "string",
-                                "description": "The status of the request. [Ex: failed]",
+                                "description": "The command result. `failed`",
                                 "enum": [
                                     "failed"
                                 ]

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -13,20 +13,23 @@
         {
             "apiKeyAuth": [],
             "protocolVersion": [],
-            "clientName": []
+            "clientName": [],
+            "format": []
         },
         {
             "username": [],
             "legacyPassword": [],
             "protocolVersion": [],
-            "clientName": []
+            "clientName": [],
+            "format": []
         },
         {
             "username": [],
             "token": [],
             "salt": [],
             "protocolVersion": [],
-            "clientName": []
+            "clientName": [],
+            "format": []
         }
     ],
     "paths": {
@@ -47,9 +50,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -89,9 +89,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -133,9 +131,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -180,9 +175,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -233,9 +226,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -284,9 +274,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -337,9 +325,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -388,9 +373,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -445,9 +428,6 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -502,9 +482,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -537,9 +515,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -579,9 +554,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -637,9 +610,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -697,9 +667,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -894,9 +862,6 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1018,9 +983,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1053,9 +1016,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1095,9 +1055,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1130,9 +1088,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1172,9 +1127,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1207,9 +1160,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1249,9 +1199,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1284,9 +1232,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1326,9 +1271,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1361,9 +1304,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1403,9 +1343,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1438,9 +1376,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1480,9 +1415,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1515,9 +1448,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1557,9 +1487,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1592,9 +1520,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1630,9 +1555,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1661,9 +1584,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1703,9 +1623,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1734,9 +1652,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1783,9 +1698,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1825,9 +1738,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1874,9 +1784,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -1916,9 +1824,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -1965,9 +1870,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2065,9 +1968,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2142,9 +2042,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2242,9 +2140,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2319,9 +2214,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2361,9 +2254,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2410,9 +2300,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2473,9 +2361,6 @@
                             "type": "boolean",
                             "default": false
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2533,9 +2418,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2596,9 +2479,6 @@
                             "type": "boolean",
                             "default": false
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2656,9 +2536,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2698,9 +2576,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2744,9 +2619,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2785,9 +2658,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -2827,9 +2697,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2854,9 +2722,7 @@
                     "Bookmarks"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2893,9 +2759,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -2948,9 +2812,6 @@
                                 "vtt"
                             ]
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3011,9 +2872,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3051,9 +2910,7 @@
                     "Chat"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3090,9 +2947,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3141,9 +2996,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3187,9 +3039,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3214,9 +3064,7 @@
                     "Browsing"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3253,9 +3101,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3304,9 +3150,6 @@
                         "schema": {
                             "type": "integer"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3354,9 +3197,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3388,9 +3229,7 @@
                     "Internet Radio"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3427,9 +3266,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3461,9 +3298,7 @@
                     "System"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3500,9 +3335,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3551,9 +3384,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3601,9 +3431,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3639,9 +3467,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3691,9 +3516,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3736,9 +3559,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3785,9 +3605,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3819,9 +3637,7 @@
                     "Browsing"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3858,9 +3674,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3901,9 +3715,6 @@
                             "type": "integer",
                             "default": 20
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -3948,9 +3759,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -3982,9 +3791,7 @@
                     "Lists"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4021,9 +3828,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4052,9 +3857,7 @@
                 ],
                 "security": [],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4092,9 +3895,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4134,9 +3935,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4183,9 +3981,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4225,9 +4021,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4271,9 +4064,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4305,9 +4096,7 @@
                     "Bookmarks"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4344,9 +4133,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4386,9 +4173,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4438,9 +4222,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4493,9 +4275,6 @@
                             "type": "boolean",
                             "default": true
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4544,9 +4323,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4625,9 +4402,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4690,9 +4464,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4724,9 +4496,7 @@
                     "Media Library Scanning"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4763,9 +4533,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4797,9 +4565,7 @@
                     "Sharing"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4836,9 +4602,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4889,9 +4653,6 @@
                             "default": 50,
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -4944,9 +4705,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -4997,9 +4756,6 @@
                             "default": 50,
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5052,9 +4808,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5094,9 +4848,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5143,9 +4894,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5213,9 +4962,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5279,9 +5025,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5321,9 +5065,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5361,9 +5102,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5403,9 +5142,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5443,9 +5179,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5496,9 +5230,6 @@
                             "default": 50,
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5551,9 +5282,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5593,9 +5322,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5642,9 +5368,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5676,9 +5400,7 @@
                     "User Management"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5715,9 +5437,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5757,9 +5477,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -5806,9 +5523,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5840,9 +5555,7 @@
                     "Browsing"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5879,9 +5592,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -5939,9 +5650,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6002,9 +5710,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6091,9 +5797,6 @@
                             "minimum": 0.0,
                             "maximum": 1.0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6161,9 +5864,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6195,9 +5896,7 @@
                     "System"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6227,9 +5926,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6254,9 +5951,7 @@
                     "Podcast"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6286,9 +5981,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6340,9 +6033,6 @@
                             "type": "integer",
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6388,9 +6078,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6439,9 +6127,6 @@
                             "type": "boolean",
                             "default": true
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6491,9 +6176,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6587,9 +6270,6 @@
                             "type": "integer",
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6664,9 +6344,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6781,9 +6459,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -6870,9 +6545,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -6987,9 +6660,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7076,9 +6746,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7129,9 +6797,6 @@
                             "minimum": 0,
                             "maximum": 5
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7178,9 +6843,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7242,9 +6905,6 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7298,9 +6958,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7325,9 +6983,7 @@
                     "Media Library Scanning"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7364,9 +7020,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7465,9 +7119,6 @@
                             "type": "boolean",
                             "default": false
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7536,9 +7187,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7559,9 +7208,7 @@
                     "System"
                 ],
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7601,9 +7248,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7679,9 +7324,6 @@
                                 "type": "string"
                             }
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7723,9 +7365,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7785,9 +7425,6 @@
                         "schema": {
                             "type": "string"
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7841,9 +7478,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -7931,9 +7566,6 @@
                                 "type": "integer"
                             }
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -7999,9 +7631,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -8053,9 +7683,6 @@
                             "type": "integer",
                             "minimum": 0
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -8104,9 +7731,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -8317,9 +7942,6 @@
                                 320
                             ]
                         }
-                    },
-                    {
-                        "$ref": "#/components/parameters/f"
                     }
                 ],
                 "responses": {
@@ -8456,9 +8078,7 @@
                     }
                 },
                 "parameters": [
-                    {
-                        "$ref": "#/components/parameters/f"
-                    }
+
                 ],
                 "responses": {
                     "200": {
@@ -8559,6 +8179,12 @@
                 "type": "apiKey",
                 "name": "c",
                 "description": "A unique string identifying the client application.",
+                "in": "query"
+            },
+            "format": {
+                "name": "f",
+                "type": "apiKey",
+                "description": "The response format. Must be 'xml' or 'json'. For the purposes of this document, only `json` is allowed.",
                 "in": "query"
             }
         },

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -2792,14 +2792,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "Successful or failed response",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/responses/BinaryResponse"
-                                }
-                            }
-                        }
+                        "$ref": "#/components/responses/BinaryResponse"
                     }
                 },
                 "externalDocs": {

--- a/static/openapi.json
+++ b/static/openapi.json
@@ -1,0 +1,12837 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "OpenSubsonic API",
+        "version": "1.16.1"
+    },
+    "servers": [
+        {
+            "url": "https://api.server.test/v1"
+        }
+    ],
+    "security": [
+        {
+            "apiKeyAuth": [],
+            "protocolVersion": [],
+            "clientName": []
+        },
+        {
+            "username": [],
+            "legacyPassword": [],
+            "protocolVersion": [],
+            "clientName": []
+        },
+        {
+            "username": [],
+            "token": [],
+            "salt": [],
+            "protocolVersion": [],
+            "clientName": []
+        }
+    ],
+    "paths": {
+        "/rest/addChatMessage": {
+            "get": {
+                "summary": "Adds a message to the chat log.",
+                "description": "Adds a message to the chat log.",
+                "operationId": "getAddChatMessage",
+                "tags": [
+                    "Chat"
+                ],
+                "parameters": [
+                    {
+                        "name": "message",
+                        "in": "query",
+                        "description": "The chat message.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "addChatMessage",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/addchatmessage/"
+                }
+            },
+            "post": {
+                "summary": "Adds a message to the chat log.",
+                "description": "Adds a message to the chat log.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postAddChatMessage",
+                "tags": [
+                    "Chat"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "message": {
+                                        "type": "string",
+                                        "description": "The chat message."
+                                    }
+                                },
+                                "required": [
+                                    "message"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "addChatMessage",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/addchatmessage/"
+                }
+            }
+        },
+        "/rest/changePassword": {
+            "get": {
+                "summary": "Changes the password of an existing user on the server.",
+                "description": "Changes the password of an existing user on the server, using the following parameters. You can only change your own password unless you have admin privileges.",
+                "tags": [
+                    "User Management"
+                ],
+                "operationId": "changePassword",
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The name of the user which should change its password.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "description": "The new password of the new user, either in clear text of hex-encoded (see above).",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "changePassword",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/changepassword/"
+                }
+            },
+            "post": {
+                "summary": "Changes the password of an existing user on the server.",
+                "description": "Changes the password of an existing user on the server, using the following parameters. You can only change your own password unless you have admin privileges.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postChangePassword",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The name of the user which should change its password."
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The new password of the new user, either in clear text of hex-encoded (see above)."
+                                    }
+                                },
+                                "required": [
+                                    "username",
+                                    "password"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "changePassword",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/changepassword/"
+                }
+            }
+        },
+        "/rest/createBookmark": {
+            "get": {
+                "summary": "Creates or updates a bookmark.",
+                "description": "Creates or updates a bookmark (a position within a media file). Bookmarks are personal and not visible to other users.",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "operationId": "createBookmark",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the media file to bookmark. If a bookmark already exists for this file it will be overwritten.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "position",
+                        "in": "query",
+                        "description": "The position (in milliseconds) within the media file.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "comment",
+                        "in": "query",
+                        "description": "A user-defined comment.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createBookmark",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createbookmark/"
+                }
+            },
+            "post": {
+                "summary": "Creates or updates a bookmark.",
+                "description": "Creates or updates a bookmark (a position within a media file). Bookmarks are personal and not visible to other users.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postCreateBookmark",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of the media file to bookmark. If a bookmark already exists for this file it will be overwritten."
+                                    },
+                                    "position": {
+                                        "type": "integer",
+                                        "description": "The position (in milliseconds) within the media file."
+                                    },
+                                    "comment": {
+                                        "type": "string",
+                                        "description": "A user-defined comment."
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "position"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createBookmark",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createbookmark/"
+                }
+            }
+        },
+        "/rest/createInternetRadioStation": {
+            "get": {
+                "summary": "Adds a new internet radio station.",
+                "description": "Adds a new internet radio station. Only users with admin privileges are allowed to call this method.",
+                "operationId": "createInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "parameters": [
+                    {
+                        "name": "streamUrl",
+                        "in": "query",
+                        "description": "The stream URL for the station.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "The station name.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "homepageUrl",
+                        "in": "query",
+                        "description": "The home page URL for the station.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createinternetradiostation/"
+                }
+            },
+            "post": {
+                "summary": "Adds a new internet radio station.",
+                "description": "Adds a new internet radio station. Only users with admin privileges are allowed to call this method.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postCreateInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "streamUrl": {
+                                        "type": "string",
+                                        "description": "The stream URL for the station."
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The station name."
+                                    },
+                                    "homepageUrl": {
+                                        "type": "string",
+                                        "description": "The home page URL for the station."
+                                    }
+                                },
+                                "required": [
+                                    "streamUrl",
+                                    "name"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createinternetradiostation/"
+                }
+            }
+        },
+        "/rest/createPlaylist": {
+            "get": {
+                "summary": "Creates (or updates) a playlist.",
+                "description": "Creates (or updates) a playlist.",
+                "operationId": "createPlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "parameters": [
+                    {
+                        "name": "playlistId",
+                        "in": "query",
+                        "description": "The playlist ID. Required if updating an existing playlist.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "The human-readable name of the playlist. Required if creating a new playlist.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "songId",
+                        "in": "query",
+                        "description": "ID of a song in the playlist. Use one `songId` parameter for each song in the playlist.",
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreatePlaylistResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "createPlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createplaylist/"
+                }
+            },
+            "post": {
+                "summary": "Creates (or updates) a playlist.",
+                "description": "Creates (or updates) a playlist.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postCreatePlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "playlistId": {
+                                        "type": "string",
+                                        "description": "The playlist ID. Required if updating an existing playlist."
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The human-readable name of the playlist. Required if creating a new playlist."
+                                    },
+                                    "songId": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "ID of a song in the playlist. Use one `songId` parameter for each song in the playlist."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createPlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createplaylist/"
+                }
+            }
+        },
+        "/rest/createPodcastChannel": {
+            "get": {
+                "summary": "Adds a new Podcast channel.",
+                "description": "Adds a new Podcast channel. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).",
+                "operationId": "createPodcastChannel",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "url",
+                        "in": "query",
+                        "description": "The URL of the Podcast to add.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createPodcastChannel",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createpodcastchannel/"
+                }
+            },
+            "post": {
+                "summary": "Adds a new Podcast channel.",
+                "description": "Adds a new Podcast channel. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postCreatePodcastChannel",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "url": {
+                                        "type": "string",
+                                        "description": "The URL of the Podcast to add."
+                                    }
+                                },
+                                "required": [
+                                    "url"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createPodcastChannel",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createpodcastchannel/"
+                }
+            }
+        },
+        "/rest/createShare": {
+            "get": {
+                "summary": "Creates a public URL that can be used by anyone to stream music or video from the server.",
+                "description": "Creates a public URL that can be used by anyone to stream music or video from the server. The URL is short and suitable for posting on Facebook, Twitter etc. Note: The user must be authorized to share (see Settings > Users > User is allowed to share files with anyone). Since 1.6.0.",
+                "operationId": "createShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of a song, album or video to share. Use one id parameter for each entry to share.",
+                        "explode": true,
+                        "required": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "description",
+                        "in": "query",
+                        "description": "A user-defined description that will be displayed to people visiting the shared media.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "expires",
+                        "in": "query",
+                        "description": "The time at which the share expires. Given as milliseconds since 1970.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CreateSharesResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "createShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createshare/"
+                }
+            },
+            "post": {
+                "summary": "Creates a public URL that can be used by anyone to stream music or video from the server.",
+                "description": "Creates a public URL that can be used by anyone to stream music or video from the server. The URL is short and suitable for posting on Facebook, Twitter etc. Note: The user must be authorized to share (see Settings > Users > User is allowed to share files with anyone). Since 1.6.0.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`).",
+                "operationId": "postCreateShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "ID of a song, album or video to share. Use one id parameter for each entry to share."
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "description": "A user-defined description that will be displayed to people visiting the shared media."
+                                    },
+                                    "expires": {
+                                        "type": "integer",
+                                        "description": "The time at which the share expires. Given as milliseconds since 1970."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createshare/"
+                }
+            }
+        },
+        "/rest/createUser": {
+            "get": {
+                "summary": "Creates a new user on the server.",
+                "description": "Creates a new user on the server.",
+                "operationId": "createUser",
+                "tags": [
+                    "User Management"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The name of the new user.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "description": "The password of the new user, either in clear text of hex-encoded (see above).",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "The email address of the new user.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ldapAuthenticated",
+                        "in": "query",
+                        "description": "Whether the user is authenticated in LDAP.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "adminRole",
+                        "in": "query",
+                        "description": "Whether the user is administrator.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "settingsRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to change personal settings and password.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "name": "streamRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to play files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "name": "jukeboxRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to play files in jukebox mode.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "downloadRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to download files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "uploadRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to upload files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "playlistRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to create and delete playlists. Since 1.8.0, changing this role has no effect.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "coverArtRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to change cover art and tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "commentRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to create and edit comments and ratings.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "podcastRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to administrate Podcasts.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "shareRole",
+                        "in": "query",
+                        "description": "(Since 1.8.0) Whether the user is allowed to share files with anyone.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "videoConversionRole",
+                        "in": "query",
+                        "description": "(Since 1.15.0) Whether the user is allowed to start video conversions.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) IDs of the music folders the user is allowed access to. Include the parameter once for each folder. Default all folders.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createuser/"
+                }
+            },
+            "post": {
+                "summary": "Creates a new user on the server.",
+                "description": "Creates a new user on the server.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postCreateUser",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The name of the new user."
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The password of the new user, either in clear text or hex-encoded."
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "description": "The email address of the new user."
+                                    },
+                                    "ldapAuthenticated": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is authenticated in LDAP.",
+                                        "default": false
+                                    },
+                                    "adminRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is administrator.",
+                                        "default": false
+                                    },
+                                    "settingsRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to change personal settings and password.",
+                                        "default": true
+                                    },
+                                    "streamRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to play files.",
+                                        "default": true
+                                    },
+                                    "jukeboxRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to play files in jukebox mode.",
+                                        "default": false
+                                    },
+                                    "downloadRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to download files.",
+                                        "default": false
+                                    },
+                                    "uploadRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to upload files.",
+                                        "default": false
+                                    },
+                                    "playlistRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to create and delete playlists. Since 1.8.0, changing this role has no effect.",
+                                        "default": false
+                                    },
+                                    "coverArtRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to change cover art and tags.",
+                                        "default": false
+                                    },
+                                    "commentRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to create and edit comments and ratings.",
+                                        "default": false
+                                    },
+                                    "podcastRole": {
+                                        "type": "boolean",
+                                        "description": "Whether the user is allowed to administrate Podcasts.",
+                                        "default": false
+                                    },
+                                    "shareRole": {
+                                        "type": "boolean",
+                                        "description": "(Since 1.8.0) Whether the user is allowed to share files with anyone.",
+                                        "default": false
+                                    },
+                                    "videoConversionRole": {
+                                        "type": "boolean",
+                                        "description": "(Since 1.15.0) Whether the user is allowed to start video conversions.",
+                                        "default": false
+                                    },
+                                    "musicFolderId": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "(Since 1.12.0) IDs of the music folders the user is allowed access to. Include the parameter once for each folder. Default all folders."
+                                    }
+                                },
+                                "required": [
+                                    "username",
+                                    "password",
+                                    "email"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "createUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createuser/"
+                }
+            }
+        },
+        "/rest/deleteBookmark": {
+            "get": {
+                "summary": "Deletes a bookmark.",
+                "description": "Deletes a bookmark (a position within a media file). Bookmarks are personal and not visible to other users.",
+                "operationId": "deleteBookmark",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the media file for which to delete the bookmark. Other users\u2019 bookmarks are not affected.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteBookmark",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletebookmark/"
+                }
+            },
+            "post": {
+                "summary": "Deletes a bookmark.",
+                "description": "Deletes a bookmark (a position within a media file). Bookmarks are personal and not visible to other users.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeleteBookmark",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of the media file for which to delete the bookmark. Other users’ bookmarks are not affected."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteBookmark",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletebookmark/"
+                }
+            }
+        },
+        "/rest/deleteInternetRadioStation": {
+            "get": {
+                "summary": "Deletes an existing internet radio station.",
+                "description": "Deletes an existing internet radio station. Only users with admin privileges are allowed to call this method.",
+                "operationId": "deleteInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID for the station.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteinternetradiostation/"
+                }
+            },
+            "post": {
+                "summary": "Deletes an existing internet radio station.",
+                "description": "Deletes an existing internet radio station. Only users with admin privileges are allowed to call this method.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeleteInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID for the station."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteinternetradiostation/"
+                }
+            }
+        },
+        "/rest/deletePlaylist": {
+            "get": {
+                "summary": "Deletes a saved playlist.",
+                "description": "Deletes a saved playlist.",
+                "operationId": "deletePlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the playlist to delete, as obtained by `getPlaylists`.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteplaylist/"
+                }
+            },
+            "post": {
+                "summary": "Deletes a saved playlist.",
+                "description": "Deletes a saved playlist.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeletePlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of the playlist to delete, as obtained by `getPlaylists`."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteplaylist/"
+                }
+            }
+        },
+        "/rest/deletePodcastChannel": {
+            "get": {
+                "summary": "Deletes a Podcast channel.",
+                "description": "Deletes a Podcast channel. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).",
+                "operationId": "deletePodcastChannel",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the Podcast channel to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePodcastChannel",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletepodcastchannel/"
+                }
+            },
+            "post": {
+                "summary": "Deletes a Podcast channel.",
+                "description": "Deletes a Podcast channel. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeletePodcastChannel",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the Podcast channel to delete."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePodcastChannel",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletepodcastchannel/"
+                }
+            }
+        },
+        "/rest/deletePodcastEpisode": {
+            "get": {
+                "summary": "Deletes a Podcast episode.",
+                "description": "Deletes a Podcast episode. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).",
+                "operationId": "deletePodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the Podcast episode to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePodcastEpisode",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletepodcastepisode/"
+                }
+            },
+            "post": {
+                "summary": "Deletes a Podcast episode.",
+                "description": "Deletes a Podcast episode. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeletePodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the Podcast episode to delete."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deletePodcastEpisode",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deletepodcastepisode/"
+                }
+            }
+        },
+        "/rest/deleteShare": {
+            "get": {
+                "summary": "Deletes an existing share.",
+                "description": "Deletes an existing share",
+                "operationId": "deleteShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the share to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteshare/"
+                }
+            },
+            "post": {
+                "summary": "Deletes an existing share.",
+                "description": "Deletes an existing share.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeleteShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of the share to delete."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteshare/"
+                }
+            }
+        },
+        "/rest/deleteUser": {
+            "get": {
+                "summary": "Deletes an existing user on the server.",
+                "description": "Deletes an existing user on the server.",
+                "operationId": "deleteUser",
+                "tags": [
+                    "User Management"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The name of the user to delete.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteuser/"
+                }
+            },
+            "post": {
+                "summary": "Deletes an existing user on the server.",
+                "description": "Deletes an existing user on the server.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDeleteUser",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The name of the user to delete."
+                                    }
+                                },
+                                "required": [
+                                    "username"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "deleteUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/deleteuser/"
+                }
+            }
+        },
+        "/rest/download": {
+            "get": {
+                "summary": "Downloads a given media file.",
+                "description": "Downloads a given media file. Similar to stream, but this method returns the original media data without transcoding or downsampling.",
+                "operationId": "download",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the file to stream. Obtained by calls to getMusicDirectory.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    }
+                }
+            },
+            "post": {
+                "summary": "Downloads a given media file.",
+                "description": "Downloads a given media file. Similar to stream, but this method returns the original media data without transcoding or downsampling.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDownload",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "A string which uniquely identifies the file to download. Obtained by calls to getMusicDirectory."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/downloadPodcastEpisode": {
+            "get": {
+                "summary": "Request the server to start downloading a given Podcast episode.",
+                "description": "Request the server to start downloading a given Podcast episode. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).",
+                "operationId": "downloadPodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the Podcast episode to download",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "downloadPodcastEpisode",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/downloadpodcastepisode/"
+                }
+            },
+            "post": {
+                "summary": "Request the server to start downloading a given Podcast episode.",
+                "description": "Request the server to start downloading a given Podcast episode. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postDownloadPodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the Podcast episode to download."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/getAlbum": {
+            "get": {
+                "summary": "Returns details for an album.",
+                "description": "Returns details for an album, including a list of songs. This method organizes music according to ID3 tags.",
+                "operationId": "getAlbum",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The album ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbum",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbum/"
+                }
+            },
+            "post": {
+                "summary": "Returns details for an album.",
+                "description": "Returns details for an album, including a list of songs. This method organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAlbum",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The album ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbum",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbum/"
+                }
+            }
+        },
+        "/rest/getAlbumInfo": {
+            "get": {
+                "summary": "Returns album info.",
+                "description": "Returns album notes, image URLs etc, using data from last.fm.",
+                "operationId": "getAlbumInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The album ID or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumInfoResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbuminfo/"
+                }
+            },
+            "post": {
+                "summary": "Returns album info.",
+                "description": "Returns album notes, image URLs etc, using data from last.fm.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAlbumInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The album ID or song ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbuminfo/"
+                }
+            }
+        },
+        "/rest/getAlbumInfo2": {
+            "get": {
+                "summary": "Returns album info (v2).",
+                "description": "Similar to getAlbumInfo, but organizes music according to ID3 tags.",
+                "operationId": "getAlbumInfo2",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The album ID or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumInfoResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumInfo2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbuminfo2/"
+                }
+            },
+            "post": {
+                "summary": "Returns album info (v2).",
+                "description": "Similar to getAlbumInfo, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAlbumInfo2",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The album ID or song ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumInfo2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbuminfo2/"
+                }
+            }
+        },
+        "/rest/getAlbumList": {
+            "get": {
+                "summary": "Returns a list of random, newest, highest rated etc. albums.",
+                "description": "Returns a list of random, newest, highest rated etc. albums. Similar to the album lists on the home page of the Subsonic web interface.",
+                "operationId": "getAlbumList",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/AlbumListType"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The number of albums to return. Max 500.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 500
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The list offset. Useful if you for example want to page through the list of newest albums.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "fromYear",
+                        "in": "query",
+                        "description": "Required if `type=='byYear'`. The first year in the range. If `fromYear` > `toYear` a reverse chronological list is returned.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "toYear",
+                        "in": "query",
+                        "description": "Required if `type=='byYear'`. The last year in the range.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "genre",
+                        "in": "query",
+                        "description": "Required if `type=='byGenre'`. The name of the genre, e.g., “Rock”.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.11.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumListResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumList",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist/"
+                }
+            },
+            "post": {
+                "summary": "Returns a list of random, newest, highest rated etc. albums.",
+                "description": "Returns a list of random, newest, highest rated etc. albums. Similar to the album lists on the home page of the Subsonic web interface.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAlbumList",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "$ref": "#/components/schemas/AlbumListType"
+                                    },
+                                    "size": {
+                                        "type": "integer",
+                                        "description": "The number of albums to return. Max 500.",
+                                        "default": 10,
+                                        "minimum": 1,
+                                        "maximum": 500
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "description": "The list offset. Useful if you for example want to page through the list of newest albums.",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "fromYear": {
+                                        "type": "integer",
+                                        "description": "Required if `type=='byYear'`. The first year in the range. If `fromYear` > `toYear` a reverse chronological list is returned."
+                                    },
+                                    "toYear": {
+                                        "type": "integer",
+                                        "description": "Required if `type=='byYear'`. The last year in the range."
+                                    },
+                                    "genre": {
+                                        "type": "string",
+                                        "description": "Required if `type=='byGenre'`. The name of the genre, e.g., “Rock”."
+                                    },
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "(Since 1.11.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumListResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumList",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist/"
+                }
+            }
+        },
+        "/rest/getAlbumList2": {
+            "get": {
+                "summary": "Returns a list of random, newest, highest rated etc. albums (v2).",
+                "description": "Similar to `getAlbumList`, but organizes music according to ID3 tags.",
+                "operationId": "getAlbumList2",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/AlbumListType"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The number of albums to return. Max 500.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 1,
+                            "maximum": 500
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The list offset. Useful if you for example want to page through the list of newest albums.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "fromYear",
+                        "in": "query",
+                        "description": "Required if `type=='byYear'`. The first year in the range. If `fromYear` > `toYear` a reverse chronological list is returned.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "toYear",
+                        "in": "query",
+                        "description": "Required if `type=='byYear'`. The last year in the range.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "genre",
+                        "in": "query",
+                        "description": "Required if `type=='byGenre'`. The name of the genre, e.g., “Rock”.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.11.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumList2Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumList2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist2/"
+                }
+            },
+            "post": {
+                "summary": "Returns a list of random, newest, highest rated etc. albums (v2).",
+                "description": "Similar to `getAlbumList`, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAlbumList2",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "type": {
+                                        "$ref": "#/components/schemas/AlbumListType"
+                                    },
+                                    "size": {
+                                        "type": "integer",
+                                        "description": "The number of albums to return. Max 500.",
+                                        "default": 10,
+                                        "minimum": 1,
+                                        "maximum": 500
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "description": "The list offset. Useful if you for example want to page through the list of newest albums.",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "fromYear": {
+                                        "type": "integer",
+                                        "description": "Required if `type=='byYear'`. The first year in the range. If `fromYear` > `toYear` a reverse chronological list is returned."
+                                    },
+                                    "toYear": {
+                                        "type": "integer",
+                                        "description": "Required if `type=='byYear'`. The last year in the range."
+                                    },
+                                    "genre": {
+                                        "type": "string",
+                                        "description": "Required if `type=='byGenre'`. The name of the genre, e.g., “Rock”."
+                                    },
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "(Since 1.11.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                },
+                                "required": [
+                                    "type"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetAlbumList2Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAlbumList2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist2/"
+                }
+            }
+        },
+        "/rest/getArtist": {
+            "get": {
+                "summary": "Returns details for an artist.",
+                "description": "Returns details for an artist, including a list of albums. This method organizes music according to ID3 tags.",
+                "operationId": "getArtist",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartist/"
+                }
+            },
+            "post": {
+                "summary": "Returns details for an artist.",
+                "description": "Returns details for an artist, including a list of albums. This method organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetArtist",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The artist ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartist/"
+                }
+            }
+        },
+        "/rest/getArtistInfo": {
+            "get": {
+                "summary": "Returns artist info.",
+                "description": "Returns artist info with biography, image URLs and similar artists, using data from last.fm.",
+                "operationId": "getArtistInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist, album or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Max number of similar artists to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "includeNotPresent",
+                        "in": "query",
+                        "description": "Whether to return artists that are not present in the media library.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistInfoResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtistInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo/"
+                }
+            },
+            "post": {
+                "summary": "Returns artist info.",
+                "description": "Returns artist info with biography, image URLs and similar artists, using data from last.fm.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetArtistInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The artist, album or song ID."
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "Max number of similar artists to return.",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "includeNotPresent": {
+                                        "type": "boolean",
+                                        "description": "Whether to return artists that are not present in the media library.",
+                                        "default": false
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtistInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo/"
+                }
+            }
+        },
+        "/rest/getArtistInfo2": {
+            "get": {
+                "summary": "Returns artist info (v2).",
+                "description": "Similar to `getArtistInfo`, but organizes music according to ID3 tags.",
+                "operationId": "getArtistInfo2",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist, album or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Max number of similar artists to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "includeNotPresent",
+                        "in": "query",
+                        "description": "Whether to return artists that are not present in the media library.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistInfo2Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtistInfo2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo2/"
+                }
+            },
+            "post": {
+                "summary": "Returns artist info (v2).",
+                "description": "Similar to `getArtistInfo`, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetArtistInfo2",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The artist, album or song ID."
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "Max number of similar artists to return.",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "includeNotPresent": {
+                                        "type": "boolean",
+                                        "description": "Whether to return artists that are not present in the media library.",
+                                        "default": false
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistInfo2Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtistInfo2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo2/"
+                }
+            }
+        },
+        "/rest/getArtists": {
+            "get": {
+                "summary": "Returns all artists.",
+                "description": "Similar to `getIndexes`, but organizes music according to ID3 tags.",
+                "operationId": "getArtists",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtists",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartists/"
+                }
+            },
+            "post": {
+                "summary": "Returns all artists.",
+                "description": "Similar to `getIndexes`, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetArtists",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetArtistsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getArtists",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartists/"
+                }
+            }
+        },
+        "/rest/getAvatar": {
+            "get": {
+                "summary": "Returns the avatar (personal image) for a user.",
+                "description": "Returns the avatar (personal image) for a user.",
+                "operationId": "getAvatar",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/responses/BinaryResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAvatar",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getavatar/"
+                }
+            },
+            "post": {
+                "summary": "Returns the avatar (personal image) for a user.",
+                "description": "Returns the avatar (personal image) for a user.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetAvatar",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The username for which to retrieve the avatar."
+                                    }
+                                },
+                                "required": [
+                                    "username"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getAvatar",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getavatar/"
+                }
+            }
+        },
+        "/rest/getBookmarks": {
+            "get": {
+                "summary": "Returns all bookmarks for this user.",
+                "description": "Returns all bookmarks for this user. A bookmark is a position within a certain media file.",
+                "operationId": "getBookmarks",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetBookmarksResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getBookmarks",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getbookmarks/"
+                }
+            },
+            "post": {
+                "summary": "Returns all bookmarks for this user.",
+                "description": "Returns all bookmarks for this user. A bookmark is a position within a certain media file.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetBookmarks",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetBookmarksResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getBookmarks",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getbookmarks/"
+                }
+            }
+        },
+        "/rest/getCaptions": {
+            "get": {
+                "summary": "Returns captions (subtitles) for a video.",
+                "description": "Returns captions (subtitles) for a video. Use `getVideoInfo` to get a list of available captions.",
+                "operationId": "getCaptions",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the video.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "description": "Preferred captions format (“srt” or “vtt”).",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "srt",
+                                "vtt"
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the raw video captions.",
+                        "content": {
+                            "application/binary": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            },
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getCaptions",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getcaptions/"
+                }
+            },
+            "post": {
+                "summary": "Returns captions (subtitles) for a video.",
+                "description": "Returns captions (subtitles) for a video. Use `getVideoInfo` to get a list of available captions.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetCaptions",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the video."
+                                    },
+                                    "format": {
+                                        "type": "string",
+                                        "description": "Preferred captions format (“srt” or “vtt”).",
+                                        "enum": [
+                                            "srt",
+                                            "vtt"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Returns the raw video captions.",
+                        "content": {
+                            "application/binary": {
+                                "schema": {
+                                    "type": "string",
+                                    "format": "binary"
+                                }
+                            },
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getCaptions",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getcaptions/"
+                }
+            }
+        },
+        "/rest/getChatMessages": {
+            "get": {
+                "summary": "Returns the current visible (non-expired) chat messages.",
+                "description": "Returns the current visible (non-expired) chat messages.",
+                "operationId": "getChatMessages",
+                "tags": [
+                    "Chat"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetChatMessagesResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getChatMessages",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getchatmessages/"
+                }
+            },
+            "post": {
+                "summary": "Returns the current visible (non-expired) chat messages.",
+                "description": "Returns the current visible (non-expired) chat messages.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetChatMessages",
+                "tags": [
+                    "Chat"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetChatMessagesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getChatMessages",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getchatmessages/"
+                }
+            }
+        },
+        "/rest/getCoverArt": {
+            "get": {
+                "summary": "Returns a cover art image.",
+                "description": "Returns a cover art image.",
+                "operationId": "getCoverArt",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The coverArt ID. Returned by most entities likes `Child` or `AlbumID3`",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "If specified, scale image to this size.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getCoverArt",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getcoverart/"
+                }
+            },
+            "post": {
+                "summary": "Returns a cover art image.",
+                "description": "Returns a cover art image.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetCoverArt",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The coverArt ID. Returned by most entities likes `Child` or `AlbumID3`"
+                                    },
+                                    "size": {
+                                        "type": "integer",
+                                        "description": "If specified, scale image to this size."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getCoverArt",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getcoverart/"
+                }
+            }
+        },
+        "/rest/getGenres": {
+            "get": {
+                "summary": "Returns all genres.",
+                "description": "Returns all genres.",
+                "operationId": "getGenres",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetGenresResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getGenres",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getgenres/"
+                }
+            },
+            "post": {
+                "summary": "Returns all genres.",
+                "description": "Returns all genres.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetGenres",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetGenresResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getGenres",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getgenres/"
+                }
+            }
+        },
+        "/rest/getIndexes": {
+            "get": {
+                "summary": "Returns an indexed structure of all artists.",
+                "description": "Returns an indexed structure of all artists.",
+                "operationId": "getIndexes",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ifModifiedSince",
+                        "in": "query",
+                        "description": "If specified, only return a result if the artist collection has changed since the given time (in milliseconds since 1 Jan 1970).",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetIndexesResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getIndexes",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getindexes/"
+                }
+            },
+            "post": {
+                "summary": "Returns an indexed structure of all artists.",
+                "description": "Returns an indexed structure of all artists.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetIndexes",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`."
+                                    },
+                                    "ifModifiedSince": {
+                                        "type": "integer",
+                                        "description": "If specified, only return a result if the artist collection has changed since the given time (in milliseconds since 1 Jan 1970)."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetIndexesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getIndexes",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getindexes/"
+                }
+            }
+        },
+        "/rest/getInternetRadioStations": {
+            "get": {
+                "summary": "Returns all internet radio stations.",
+                "description": "Returns all internet radio stations. Takes no extra parameters.",
+                "operationId": "getInternetRadioStations",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetInternetRadioStationsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getInternetRadioStations",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getinternetradiostations/"
+                }
+            },
+            "post": {
+                "summary": "Returns all internet radio stations.",
+                "description": "Returns all internet radio stations. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetInternetRadioStations",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetInternetRadioStationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getInternetRadioStations",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getinternetradiostations/"
+                }
+            }
+        },
+        "/rest/getLicense": {
+            "get": {
+                "summary": "Get details about the software license.",
+                "description": "Get details about the software license.",
+                "operationId": "getLicense",
+                "tags": [
+                    "System"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLicenseResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getLicense",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlicense/"
+                }
+            },
+            "post": {
+                "summary": "Get details about the software license.",
+                "description": "Get details about the software license.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetLicense",
+                "tags": [
+                    "System"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLicenseResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getLicense",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlicense/"
+                }
+            }
+        },
+        "/rest/getLyrics": {
+            "get": {
+                "summary": "Searches for and returns lyrics for a given song.",
+                "description": "Searches for and returns lyrics for a given song.",
+                "operationId": "getLyrics",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "artist",
+                        "in": "query",
+                        "description": "The artist name.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "description": "The song title.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLyricsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getLyrics",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlyrics/"
+                }
+            },
+            "post": {
+                "summary": "Searches for and returns lyrics for a given song.",
+                "description": "Searches for and returns lyrics for a given song.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetLyrics",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "artist": {
+                                        "type": "string",
+                                        "description": "The artist name."
+                                    },
+                                    "title": {
+                                        "type": "string",
+                                        "description": "The song title."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLyricsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/getLyricsBySongId": {
+            "get": {
+                "summary": "Add support for synchronized lyrics, multiple languages, and retrieval by song ID. ",
+                "description": "OpenSubsonic extension name `songLyrics` (As returned by `getOpenSubsonicExtensions`). Retrieves all structured lyrics from the server for a given song. The lyrics can come from embedded tags (SYLT/USLT), LRC file/text file, or any other external source.",
+                "operationId": "getLyricsBySongId",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The track ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLyricsBySongIdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported."
+                    }
+                },
+                "externalDocs": {
+                    "description": "getLyricsBySongId",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlyricsbysongid/"
+                }
+            },
+            "post": {
+                "summary": "Add support for synchronized lyrics, multiple languages, and retrieval by song ID.",
+                "description": "OpenSubsonic extension name `songLyrics` (As returned by `getOpenSubsonicExtensions`). Retrieves all structured lyrics from the server for a given song. The lyrics can come from embedded tags (SYLT/USLT), LRC file/text file, or any other external source.",
+                "operationId": "postGetLyricsBySongId",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The track ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetLyricsBySongIdResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported."
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getLyricsBySongId",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlyricsbysongid/"
+                }
+            }
+        },
+        "/rest/getMusicDirectory": {
+            "get": {
+                "summary": "Returns a listing of all files in a music directory.",
+                "description": "Returns a listing of all files in a music directory. Typically used to get list of albums for an artist, or list of songs for an album.",
+                "operationId": "getMusicDirectory",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the music folder. Obtained by calls to `getIndexes` or `getMusicDirectory`.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicDirectoryResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getMusicDirectory",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicdirectory/"
+                }
+            },
+            "post": {
+                "summary": "Returns a listing of all files in a music directory.",
+                "description": "Returns a listing of all files in a music directory. Typically used to get list of albums for an artist, or list of songs for an album.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetMusicDirectory",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "A string which uniquely identifies the music folder. Obtained by calls to `getIndexes` or `getMusicDirectory`."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicDirectoryResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getMusicDirectory",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicdirectory/"
+                }
+            }
+        },
+        "/rest/getMusicFolders": {
+            "get": {
+                "summary": "Returns all configured top-level music folders.",
+                "description": "Returns all configured top-level music folders. Takes no extra parameters.",
+                "operationId": "getMusicFolders",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicFoldersResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getMusicFolders",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicfolders/"
+                }
+            },
+            "post": {
+                "summary": "Returns all configured top-level music folders.",
+                "description": "Returns all configured top-level music folders. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetMusicFolders",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetMusicFoldersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getMusicFolders",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicfolders/"
+                }
+            }
+        },
+        "/rest/getNewestPodcasts": {
+            "get": {
+                "summary": "Returns the most recently published Podcast episodes.",
+                "description": "Returns the most recently published Podcast episodes.",
+                "operationId": "getNewestPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "The maximum number of episodes to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetNewestPodcastsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getNewestPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getnewestpodcasts/"
+                }
+            },
+            "post": {
+                "summary": "Returns the most recently published Podcast episodes.",
+                "description": "Returns the most recently published Podcast episodes.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetNewestPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "The maximum number of episodes to return.",
+                                        "default": 20
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetNewestPodcastsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getNewestPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getnewestpodcasts/"
+                }
+            }
+        },
+        "/rest/getNowPlaying": {
+            "get": {
+                "summary": "Returns what is currently being played by all users.",
+                "description": "Returns what is currently being played by all users. Takes no extra parameters.",
+                "operationId": "getNowPlaying",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetNowPlayingResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getNowPlaying",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getnowplaying/"
+                }
+            },
+            "post": {
+                "summary": "Returns what is currently being played by all users.",
+                "description": "Returns what is currently being played by all users. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetNowPlaying",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetNowPlayingResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/getOpenSubsonicExtensions": {
+            "get": {
+                "summary": "List the OpenSubsonic extensions supported by this server.",
+                "description": "List the OpenSubsonic extensions supported by this server.",
+                "operationId": "getOpenSubsonicExtensions",
+                "tags": [
+                    "System"
+                ],
+                "security": [],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOpenSubsonicExtensionsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getOpenSubsonicExtensions",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getopensubsonicextensions/"
+                }
+            },
+            "post": {
+                "summary": "List the OpenSubsonic extensions supported by this server.",
+                "description": "List the OpenSubsonic extensions supported by this server.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetOpenSubsonicExtensions",
+                "tags": [
+                    "System"
+                ],
+                "security": [],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetOpenSubsonicExtensionsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getOpenSubsonicExtensions",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getopensubsonicextensions/"
+                }
+            }
+        },
+        "/rest/getPlaylist": {
+            "get": {
+                "summary": "Returns a listing of files in a saved playlist.",
+                "description": "Returns a listing of files in a saved playlist.",
+                "operationId": "getPlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the playlist to return, as obtained by `getPlaylists`.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlaylistResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylist/"
+                }
+            },
+            "post": {
+                "summary": "Returns a listing of files in a saved playlist.",
+                "description": "Returns a listing of files in a saved playlist.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetPlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of the playlist to return, as obtained by `getPlaylists`."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlaylistResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylist/"
+                }
+            }
+        },
+        "/rest/getPlaylists": {
+            "get": {
+                "summary": "Returns all playlists a user is allowed to play.",
+                "description": "Returns all playlists a user is allowed to play.",
+                "operationId": "getPlaylists",
+                "tags": [
+                    "Playlists"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "(Since 1.8.0) If specified, return playlists for this user rather than for the authenticated user. The authenticated user must have admin role if this parameter is used.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlaylistsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlaylists",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylists/"
+                }
+            },
+            "post": {
+                "summary": "Returns all playlists a user is allowed to play.",
+                "description": "Returns all playlists a user is allowed to play.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetPlaylists",
+                "tags": [
+                    "Playlists"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "(Since 1.8.0) If specified, return playlists for this user rather than for the authenticated user. The authenticated user must have admin role if this parameter is used."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlaylistsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlaylists",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylists/"
+                }
+            }
+        },
+        "/rest/getPlayQueue": {
+            "get": {
+                "summary": "Returns the state of the play queue for this user.",
+                "description": "Returns the state of the play queue for this user (as set by savePlayQueue). This includes the tracks in the play queue, the currently playing track, and the position within this track. Typically used to allow a user to move between different clients/apps while retaining the same play queue (for instance when listening to an audio book).",
+                "operationId": "getPlayQueue",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlayQueueResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlayQueue",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplayqueue/"
+                }
+            },
+            "post": {
+                "summary": "Returns the state of the play queue for this user.",
+                "description": "Returns the state of the play queue for this user (as set by savePlayQueue). This includes the tracks in the play queue, the currently playing track, and the position within this track. Typically used to allow a user to move between different clients/apps while retaining the same play queue (for instance when listening to an audio book).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetPlayQueue",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPlayQueueResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPlayQueue",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplayqueue/"
+                }
+            }
+        },
+        "/rest/getPodcastEpisode": {
+            "get": {
+                "summary": "Returns details for a podcast episode.",
+                "description": "OpenSubsonic extension name getPodcastEpisode (As returned by `getOpenSubsonicExtensions`). Returns details for a podcast episode.",
+                "operationId": "getPodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The podcast episode ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPodcastEpisodeResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported."
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPodcastEpisode",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcastepisode/"
+                }
+            },
+            "post": {
+                "summary": "Returns details for a podcast episode.",
+                "description": "OpenSubsonic extension name `getPodcastEpisode` (As returned by `getOpenSubsonicExtensions`). Returns details for a podcast episode.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetPodcastEpisode",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The podcast episode ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPodcastEpisodeResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported."
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPodcastEpisode",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcastepisode/"
+                }
+            }
+        },
+        "/rest/getPodcasts": {
+            "get": {
+                "summary": "Returns all Podcast channels the server subscribes to, and (optionally) their episodes.",
+                "description": "Returns all Podcast channels the server subscribes to, and (optionally) their episodes. This method can also be used to return details for only one channel - refer to the id parameter. A typical use case for this method would be to first retrieve all channels without episodes, and then retrieve all episodes for the single channel the user selects.",
+                "operationId": "getPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "(Since 1.9.0) If specified, only return the Podcast channel with this ID.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "includeEpisodes",
+                        "in": "query",
+                        "description": "(Since 1.9.0) Whether to include Podcast episodes in the returned result.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPodcastsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcasts/"
+                }
+            },
+            "post": {
+                "summary": "Returns all Podcast channels the server subscribes to, and (optionally) their episodes.",
+                "description": "Returns all Podcast channels the server subscribes to, and (optionally) their episodes. This method can also be used to return details for only one channel - refer to the id parameter. A typical use case for this method would be to first retrieve all channels without episodes, and then retrieve all episodes for the single channel the user selects.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "(Since 1.9.0) If specified, only return the Podcast channel with this ID."
+                                    },
+                                    "includeEpisodes": {
+                                        "type": "boolean",
+                                        "description": "(Since 1.9.0) Whether to include Podcast episodes in the returned result.",
+                                        "default": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetPodcastsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcasts/"
+                }
+            }
+        },
+        "/rest/getRandomSongs": {
+            "get": {
+                "summary": "Returns random songs matching the given criteria.",
+                "description": "Returns random songs matching the given criteria.",
+                "operationId": "getRandomSongs",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "The maximum number of songs to return. Max 500.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 0,
+                            "maximum": 500
+                        }
+                    },
+                    {
+                        "name": "genre",
+                        "in": "query",
+                        "description": "Only returns songs belonging to this genre.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "fromYear",
+                        "in": "query",
+                        "description": "(Since 1.9.0) Only return songs from this year or later.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "toYear",
+                        "in": "query",
+                        "description": "Only return songs published before or in this year.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "Only return songs in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetRandomSongsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getRandomSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getrandomsongs/"
+                }
+            },
+            "post": {
+                "summary": "Returns random songs matching the given criteria.",
+                "description": "Returns random songs matching the given criteria.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetRandomSongs",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "size": {
+                                        "type": "integer",
+                                        "description": "The maximum number of songs to return. Max 500.",
+                                        "default": 10,
+                                        "minimum": 0,
+                                        "maximum": 500
+                                    },
+                                    "genre": {
+                                        "type": "string",
+                                        "description": "Only returns songs belonging to this genre."
+                                    },
+                                    "fromYear": {
+                                        "type": "integer",
+                                        "description": "(Since 1.9.0) Only return songs from this year or later."
+                                    },
+                                    "toYear": {
+                                        "type": "integer",
+                                        "description": "Only return songs published before or in this year."
+                                    },
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "Only return songs in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetRandomSongsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getRandomSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getrandomsongs/"
+                }
+            }
+        },
+        "/rest/getScanStatus": {
+            "get": {
+                "summary": "Returns the current status for media library scanning.",
+                "description": "Returns the current status for media library scanning. Takes no extra parameters.",
+                "operationId": "getScanStatus",
+                "tags": [
+                    "Media Library Scanning"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetScanStatusResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getScanStatus",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getscanstatus/"
+                }
+            },
+            "post": {
+                "summary": "Returns the current status for media library scanning.",
+                "description": "Returns the current status for media library scanning. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetScanStatus",
+                "tags": [
+                    "Media Library Scanning"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetScanStatusResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getScanStatus",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getscanstatus/"
+                }
+            }
+        },
+        "/rest/getShares": {
+            "get": {
+                "summary": "Returns information about shared media this user is allowed to manage.",
+                "description": "Returns information about shared media this user is allowed to manage. Takes no extra parameters.",
+                "operationId": "getShares",
+                "tags": [
+                    "Sharing"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSharesResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getShares",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getshares/"
+                }
+            },
+            "post": {
+                "summary": "Returns information about shared media this user is allowed to manage.",
+                "description": "Returns information about shared media this user is allowed to manage. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetShares",
+                "tags": [
+                    "Sharing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSharesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getShares",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getshares/"
+                }
+            }
+        },
+        "/rest/getSimilarSongs": {
+            "get": {
+                "summary": "Returns a random collection of songs from the given artist and similar artists.",
+                "description": "Returns a random collection of songs from the given artist and similar artists, using data from last.fm. Typically used for artist radio features.",
+                "operationId": "getSimilarSongs",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist, album or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Max number of songs to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 50,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSimilarSongsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSimilarSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs/"
+                }
+            },
+            "post": {
+                "summary": "Returns a random collection of songs from the given artist and similar artists.",
+                "description": "Returns a random collection of songs from the given artist and similar artists, using data from last.fm. Typically used for artist radio features.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetSimilarSongs",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The artist, album or song ID."
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "default": 50,
+                                        "minimum": 0,
+                                        "description": "Max number of songs to return."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSimilarSongsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSimilarSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs/"
+                }
+            }
+        },
+        "/rest/getSimilarSongs2": {
+            "get": {
+                "summary": "Returns a random collection of songs from the given artist and similar artists (v2).",
+                "description": "Similar to `getSimilarSongs`, but organizes music according to ID3 tags.",
+                "operationId": "getSimilarSongs2",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist, album or song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Max number of songs to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 50,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSimilarSongs2Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSimilarSongs2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs2/"
+                }
+            },
+            "post": {
+                "summary": "Returns a random collection of songs from the given artist and similar artists (v2).",
+                "description": "Similar to `getSimilarSongs`, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetSimilarSongs2",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The artist, album or song ID."
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "default": 50,
+                                        "minimum": 0,
+                                        "description": "Max number of songs to return."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSimilarSongs2Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSimilarSongs2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs2/"
+                }
+            }
+        },
+        "/rest/getSong": {
+            "get": {
+                "summary": "Returns details for a song.",
+                "description": "Returns details for a song.",
+                "operationId": "getSong",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The song ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSongResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSong",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsong/"
+                }
+            },
+            "post": {
+                "summary": "Returns details for a song.",
+                "description": "Returns details for a song.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetSong",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The song ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSongResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/getSongsByGenre": {
+            "get": {
+                "summary": "Returns songs in a given genre.",
+                "description": "Returns songs in a given genre.",
+                "operationId": "getSongsByGenre",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "genre",
+                        "in": "query",
+                        "description": "The genre, as returned by `getGenres`.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "The maximum number of songs to return. Max 500.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "minimum": 0,
+                            "maximum": 500
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "The offset. Useful if you want to page through the songs in a genre.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSongsByGenreResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSongsByGenre",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsongsbygenre/"
+                }
+            },
+            "post": {
+                "summary": "Returns songs in a given genre.",
+                "description": "Returns songs in a given genre.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetSongsByGenre",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "genre": {
+                                        "type": "string",
+                                        "description": "The genre, as returned by `getGenres`."
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "The maximum number of songs to return. Max 500.",
+                                        "default": 10,
+                                        "minimum": 0,
+                                        "maximum": 500
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "description": "The offset. Useful if you want to page through the songs in a genre.",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                },
+                                "required": [
+                                    "genre"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetSongsByGenreResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getSongsByGenre",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsongsbygenre/"
+                }
+            }
+        },
+        "/rest/getStarred": {
+            "get": {
+                "summary": "Returns starred songs, albums and artists.",
+                "description": "Returns starred songs, albums and artists.",
+                "operationId": "getStarred",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetStarredResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getStarred",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred/"
+                }
+            },
+            "post": {
+                "summary": "Returns starred songs, albums and artists.",
+                "description": "Returns starred songs, albums and artists.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetStarred",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetStarredResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getStarred",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred/"
+                }
+            }
+        },
+        "/rest/getStarred2": {
+            "get": {
+                "summary": "Returns starred songs, albums and artists.",
+                "description": "Similar to `getStarred`, but organizes music according to ID3 tags.",
+                "operationId": "getStarred2",
+                "tags": [
+                    "Lists"
+                ],
+                "parameters": [
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetStarred2Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getStarred2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred2/"
+                }
+            },
+            "post": {
+                "summary": "Returns starred songs, albums and artists.",
+                "description": "Similar to `getStarred`, but organizes music according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetStarred2",
+                "tags": [
+                    "Lists"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetStarred2Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getStarred2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred2/"
+                }
+            }
+        },
+        "/rest/getTopSongs": {
+            "get": {
+                "summary": "Returns top songs for the given artist.",
+                "description": "Returns top songs for the given artist, using data from last.fm.",
+                "operationId": "getTopSongs",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The artist name.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "The maximum number of songs to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 50,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetTopSongsResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getTopSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/gettopsongs/"
+                }
+            },
+            "post": {
+                "summary": "Returns top songs for the given artist.",
+                "description": "Returns top songs for the given artist, using data from last.fm.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetTopSongs",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "The artist name.",
+                                        "type": "string"
+                                    },
+                                    "count": {
+                                        "description": "The maximum number of songs to return.",
+                                        "type": "integer",
+                                        "default": 50,
+                                        "minimum": 0
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetTopSongsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getTopSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/gettopsongs/"
+                }
+            }
+        },
+        "/rest/getUser": {
+            "get": {
+                "summary": "Get details about a given user, including which authorization roles and folder access it has.",
+                "description": "Get details about a given user, including which authorization roles and folder access it has. Can be used to enable/disable certain features in the client, such as jukebox control.",
+                "operationId": "getUser",
+                "tags": [
+                    "User Management"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The name of the user to retrieve. You can only retrieve your own user unless you have admin privileges.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetUserResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getuser/"
+                }
+            },
+            "post": {
+                "summary": "Get details about a given user, including which authorization roles and folder access it has.",
+                "description": "Get details about a given user, including which authorization roles and folder access it has. Can be used to enable/disable certain features in the client, such as jukebox control.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetUser",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The name of the user to retrieve. You can only retrieve your own user unless you have admin privileges."
+                                    }
+                                },
+                                "required": [
+                                    "username"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetUserResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getuser/"
+                }
+            }
+        },
+        "/rest/getUsers": {
+            "get": {
+                "summary": "Get details about all users, including which authorization roles and folder access they have",
+                "description": "Get details about all users, including which authorization roles and folder access they have. Only users with admin privileges are allowed to call this method.",
+                "operationId": "getUsers",
+                "tags": [
+                    "User Management"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetUsersResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getUsers",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getusers/"
+                }
+            },
+            "post": {
+                "summary": "Get details about all users, including which authorization roles and folder access they have",
+                "description": "Get details about all users, including which authorization roles and folder access they have. Only users with admin privileges are allowed to call this method.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetUsers",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetUsersResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getUsers",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getusers/"
+                }
+            }
+        },
+        "/rest/getVideoInfo": {
+            "get": {
+                "summary": "Returns details for a video.",
+                "description": "Returns details for a video, including information about available audio tracks, subtitles (captions) and conversions.",
+                "operationId": "getVideoInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The video ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetVideoInfoResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getVideoInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideoinfo/"
+                }
+            },
+            "post": {
+                "summary": "Returns details for a video.",
+                "description": "Returns details for a video, including information about available audio tracks, subtitles (captions) and conversions.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetVideoInfo",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The video ID."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetVideoInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getVideoInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideoinfo/"
+                }
+            }
+        },
+        "/rest/getVideos": {
+            "get": {
+                "summary": "Returns all video files.",
+                "description": "Returns all video files.",
+                "operationId": "getVideos",
+                "tags": [
+                    "Browsing"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetVideosResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "getVideos",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideos/"
+                }
+            },
+            "post": {
+                "summary": "Returns all video files.",
+                "description": "Returns all video files.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postGetVideos",
+                "tags": [
+                    "Browsing"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetVideosResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "getVideos",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideos/"
+                }
+            }
+        },
+        "/rest/hls.m3u8": {
+            "get": {
+                "summary": "Downloads a given media file (HLS).",
+                "description": "Creates an HLS (HTTP Live Streaming) playlist used for streaming video or audio. HLS is a streaming protocol implemented by Apple and works by breaking the overall stream into a sequence of small HTTP-based file downloads. It’s supported by iOS and newer versions of Android. This method also supports adaptive bitrate streaming, see the bitRate parameter.",
+                "operationId": "hls.m3u8",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the media file to stream.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "bitRate",
+                        "in": "query",
+                        "description": "If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If this parameter is specified more than once, the server will create a variant playlist, suitable for adaptive bitrate streaming. The playlist will support streaming at all the specified bitrates. The server will automatically choose video dimensions that are suitable for the given bitrates. Since 1.9.0 you may explicitly request a certain width (480) and height (360) like so: bitRate=1000@480x360",
+                        "required": false,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "audioTrack",
+                        "in": "query",
+                        "description": "The ID of the audio track to use. See `getVideoInfo` for how to get the list of available audio tracks for a video.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/vnd.apple.mpegurl": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "Error response TODO: TO BE DESCRIBED"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "hls.m3u8",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/hls/"
+                }
+            },
+            "post": {
+                "summary": "Downloads a given media file (HLS).",
+                "description": "Creates an HLS (HTTP Live Streaming) playlist used for streaming video or audio. HLS is a streaming protocol implemented by Apple and works by breaking the overall stream into a sequence of small HTTP-based file downloads. It’s supported by iOS and newer versions of Android. This method also supports adaptive bitrate streaming, see the bitRate parameter.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postHls.m3u8",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "A string which uniquely identifies the media file to stream."
+                                    },
+                                    "bitRate": {
+                                        "type": "integer",
+                                        "description": "If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If set to zero, no limit is imposed."
+                                    },
+                                    "audioTrack": {
+                                        "type": "string",
+                                        "description": "The ID of the audio track to use. See `getVideoInfo` for how to get the list of available audio tracks for a video."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/vnd.apple.mpegurl": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            },
+                            "text/xml": {
+                                "schema": {
+                                    "type": "object",
+                                    "description": "Error response TODO: TO BE DESCRIBED"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "hls.m3u8",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/hls/"
+                }
+            }
+        },
+        "/rest/jukeboxControl": {
+            "get": {
+                "summary": "Controls the jukebox, i.e., playback directly on the server’s audio hardware.",
+                "description": "Controls the jukebox, i.e., playback directly on the server’s audio hardware. Note: The user must be authorized to control the jukebox (see Settings > Users > User is allowed to play files in jukebox mode).",
+                "operationId": "jukeboxControl",
+                "tags": [
+                    "Jukebox"
+                ],
+                "parameters": [
+                    {
+                        "name": "action",
+                        "in": "query",
+                        "description": "The operation to perform. Must be one of: get, status (since 1.7.0), set (since 1.7.0), start, stop, skip, add, clear, remove, shuffle, setGain",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/JukeboxAction"
+                        }
+                    },
+                    {
+                        "name": "index",
+                        "in": "query",
+                        "description": "Used by `skip` and `remove`. Zero-based index of the song to skip to or remove.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "(Since 1.7.0) Used by `skip`. Start playing this many seconds into the track.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "Used by `add` and `set`. ID of song to add to the jukebox playlist. Use multiple id parameters to add many songs in the same request. (set is similar to a clear followed by a add, but will not change the currently playing track.)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "gain",
+                        "in": "query",
+                        "description": "Used by `setGain` to control the playback volume. A float value between 0.0 and 1.0.",
+                        "required": false,
+                        "schema": {
+                            "type": "number",
+                            "format": "float",
+                            "minimum": 0.0,
+                            "maximum": 1.0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JukeboxControlResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "jukeboxControl",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/jukeboxcontrol/"
+                }
+            },
+            "post": {
+                "summary": "Controls the jukebox, i.e., playback directly on the server’s audio hardware.",
+                "description": "Controls the jukebox, i.e., playback directly on the server’s audio hardware. Note: The user must be authorized to control the jukebox (see Settings > Users > User is allowed to play files in jukebox mode).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postJukeboxControl",
+                "tags": [
+                    "Jukebox"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "action": {
+                                        "description": "The operation to perform. Must be one of: get, status (since 1.7.0), set (since 1.7.0), start, stop, skip, add, clear, remove, shuffle, setGain",
+                                        "type": "string"
+                                    },
+                                    "index": {
+                                        "description": "Used by `skip` and `remove`. Zero-based index of the song to skip to or remove.",
+                                        "type": "integer",
+                                        "minimum": 0
+                                    },
+                                    "offset": {
+                                        "description": "(Since 1.7.0) Used by `skip`. Start playing this many seconds into the track.",
+                                        "type": "integer",
+                                        "minimum": 0
+                                    },
+                                    "id": {
+                                        "description": "Used by `add` and `set`. ID of song to add to the jukebox playlist. Use multiple id parameters to add many songs in the same request. (set is similar to a clear followed by an add, but will not change the currently playing track.)",
+                                        "type": "string"
+                                    },
+                                    "gain": {
+                                        "description": "Used by `setGain` to control the playback volume. A float value between 0.0 and 1.0.",
+                                        "type": "number",
+                                        "format": "float",
+                                        "minimum": 0.0,
+                                        "maximum": 1.0
+                                    }
+                                },
+                                "required": [
+                                    "action"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/JukeboxControlResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "jukeboxControl",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/jukeboxcontrol/"
+                }
+            }
+        },
+        "/rest/ping": {
+            "get": {
+                "summary": "Used to test connectivity with the server.",
+                "description": "Test connectivity with the server.",
+                "operationId": "ping",
+                "tags": [
+                    "System"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "ping",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/ping/"
+                }
+            },
+            "post": {
+                "summary": "Used to test connectivity with the server.",
+                "description": "Test connectivity with the server.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postPing",
+                "tags": [
+                    "System"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "ping",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/ping/"
+                }
+            }
+        },
+        "/rest/refreshPodcasts": {
+            "get": {
+                "summary": "Requests the server to check for new Podcast episodes.",
+                "description": "Requests the server to check for new Podcast episodes. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).",
+                "operationId": "refreshPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "refreshPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/refreshpodcasts/"
+                }
+            },
+            "post": {
+                "summary": "Requests the server to check for new Podcast episodes.",
+                "description": "Requests the server to check for new Podcast episodes. Note: The user must be authorized for Podcast administration (see Settings > Users > User is allowed to administrate Podcasts).\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postRefreshPodcasts",
+                "tags": [
+                    "Podcast"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "refreshPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/refreshpodcasts/"
+                }
+            }
+        },
+        "/rest/savePlayQueue": {
+            "get": {
+                "summary": "Saves the state of the play queue for this user.",
+                "description": "Saves the state of the play queue for this user. This includes the tracks in the play queue, the currently playing track, and the position within this track. Typically used to allow a user to move between different clients/apps while retaining the same play queue (for instance when listening to an audio book). `id` is optional. Send a call without any parameters to clear the currently saved queue.",
+                "operationId": "savePlayQueue",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of a song in the play queue. Use one id parameter for each song in the play queue.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "current",
+                        "in": "query",
+                        "description": "The ID of the current playing song.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "position",
+                        "in": "query",
+                        "description": "The position in milliseconds within the currently playing song.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "savePlayQueue",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/saveplayqueue/"
+                }
+            },
+            "post": {
+                "summary": "Saves the state of the play queue for this user.",
+                "description": "Saves the state of the play queue for this user. This includes the tracks in the play queue, the currently playing track, and the position within this track. Typically used to allow a user to move between different clients/apps while retaining the same play queue (for instance when listening to an audio book). `id` is optional. Send a call without any parameters to clear the currently saved queue.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postSavePlayQueue",
+                "tags": [
+                    "Bookmarks"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "ID of a song in the play queue. Use one id parameter for each song in the play queue."
+                                    },
+                                    "current": {
+                                        "type": "string",
+                                        "description": "The ID of the current playing song."
+                                    },
+                                    "position": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "The position in milliseconds within the currently playing song."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/scrobble": {
+            "get": {
+                "summary": "Registers the local playback of one or more media files.",
+                "description": "Registers the local playback of one or more media files. Typically used when playing media that is cached on the client. This operation includes the following:\n\n* “Scrobbles” the media files on last.fm if the user has configured his/her last.fm credentials on the server.\n* Updates the play count and last played timestamp for the media files. (Since 1.11.0)\n* Makes the media files appear in the “Now playing” page in the web app, and appear in the list of songs returned by getNowPlaying (Since 1.11.0)\n\nSince 1.8.0 you may specify multiple id (and optionally time) parameters to scrobble multiple files.",
+                "operationId": "scrobble",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the file to scrobble.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "time",
+                        "in": "query",
+                        "description": "(Since 1.8.0) The time (in milliseconds since 1 Jan 1970) at which the song was listened to.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "submission",
+                        "in": "query",
+                        "description": "Whether this is a “submission” or a “now playing” notification.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "scrobble",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/scrobble/"
+                }
+            },
+            "post": {
+                "summary": "Registers the local playback of one or more media files.",
+                "description": "Registers the local playback of one or more media files. Typically used when playing media that is cached on the client. This operation includes the following:\n\n* “Scrobbles” the media files on last.fm if the user has configured his/her last.fm credentials on the server.\n* Updates the play count and last played timestamp for the media files. (Since 1.11.0)\n* Makes the media files appear in the “Now playing” page in the web app, and appear in the list of songs returned by getNowPlaying (Since 1.11.0)\n\nSince 1.8.0 you may specify multiple id (and optionally time) parameters to scrobble multiple files.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postScrobble",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "A string which uniquely identifies the file to scrobble."
+                                    },
+                                    "time": {
+                                        "type": "integer",
+                                        "description": "(Since 1.8.0) The time (in milliseconds since 1 Jan 1970) at which the song was listened to.",
+                                        "minimum": 0
+                                    },
+                                    "submission": {
+                                        "type": "boolean",
+                                        "description": "Whether this is a “submission” or a “now playing” notification.",
+                                        "default": true
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "scrobble",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/scrobble/"
+                }
+            }
+        },
+        "/rest/search": {
+            "get": {
+                "summary": "Returns a listing of files matching the given search criteria. Supports paging through the result.",
+                "deprecated": true,
+                "description": "Deprecated since 1.4.0, use search2 instead.\n\nReturns a listing of files matching the given search criteria. Supports paging through the result.",
+                "operationId": "search",
+                "tags": [
+                    "Searching"
+                ],
+                "parameters": [
+                    {
+                        "name": "artist",
+                        "in": "query",
+                        "description": "Artist to search for.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "album",
+                        "in": "query",
+                        "description": "Album to search for.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "title",
+                        "in": "query",
+                        "description": "Song title to search for.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "any",
+                        "in": "query",
+                        "description": "Searches all fields.",
+                        "allowEmptyValue": true,
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "count",
+                        "in": "query",
+                        "description": "Maximum number of results to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "offset",
+                        "in": "query",
+                        "description": "Search result offset. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "newerThan",
+                        "in": "query",
+                        "description": "Only return matches that are newer than this. Given as milliseconds since 1970.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SearchResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "search",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search/"
+                }
+            },
+            "post": {
+                "summary": "Returns a listing of files matching the given search criteria. Supports paging through the result.",
+                "deprecated": true,
+                "description": "Deprecated since 1.4.0, use search2 instead.\n\nReturns a listing of files matching the given search criteria. Supports paging through the result.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postSearch",
+                "tags": [
+                    "Searching"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "artist": {
+                                        "type": "string",
+                                        "description": "Artist to search for."
+                                    },
+                                    "album": {
+                                        "type": "string",
+                                        "description": "Album to search for."
+                                    },
+                                    "title": {
+                                        "type": "string",
+                                        "description": "Song title to search for."
+                                    },
+                                    "any": {
+                                        "type": "boolean",
+                                        "description": "Searches all fields.",
+                                        "default": false
+                                    },
+                                    "count": {
+                                        "type": "integer",
+                                        "description": "Maximum number of results to return.",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "offset": {
+                                        "type": "integer",
+                                        "description": "Search result offset. Used for paging.",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "newerThan": {
+                                        "type": "integer",
+                                        "description": "Only return matches that are newer than this. Given as milliseconds since 1970.",
+                                        "minimum": 0
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SearchResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "search",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search/"
+                }
+            }
+        },
+        "/rest/search2": {
+            "get": {
+                "summary": "Returns a listing of files matching the given search criteria. Supports paging through the result. (v2)",
+                "description": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result.",
+                "operationId": "search2",
+                "tags": [
+                    "Searching"
+                ],
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Search query.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "artistCount",
+                        "in": "query",
+                        "description": "Maximum number of artists to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "artistOffset",
+                        "in": "query",
+                        "description": "Search result offset for artists. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "albumCount",
+                        "in": "query",
+                        "description": "Maximum number of albums to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "albumOffset",
+                        "in": "query",
+                        "description": "Search result offset for albums. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "songCount",
+                        "in": "query",
+                        "description": "Maximum number of songs to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "songOffset",
+                        "in": "query",
+                        "description": "Search result offset for songs. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Search2Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "search2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search2/"
+                }
+            },
+            "post": {
+                "summary": "Returns a listing of files matching the given search criteria. Supports paging through the result. (v2)",
+                "description": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postSearch2",
+                "tags": [
+                    "Searching"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {
+                                        "description": "Search query.",
+                                        "type": "string"
+                                    },
+                                    "artistCount": {
+                                        "description": "Maximum number of artists to return.",
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "artistOffset": {
+                                        "description": "Search result offset for artists. Used for paging.",
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "albumCount": {
+                                        "description": "Maximum number of albums to return.",
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "albumOffset": {
+                                        "description": "Search result offset for albums. Used for paging.",
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "songCount": {
+                                        "description": "Maximum number of songs to return.",
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0
+                                    },
+                                    "songOffset": {
+                                        "description": "Search result offset for songs. Used for paging.",
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0
+                                    },
+                                    "musicFolderId": {
+                                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "query"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Search2Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "search2",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search2/"
+                }
+            }
+        },
+        "/rest/search3": {
+            "get": {
+                "summary": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result. (v3)",
+                "description": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result.\n\nMusic is organized according to ID3 tags.",
+                "operationId": "search3",
+                "tags": [
+                    "Searching"
+                ],
+                "parameters": [
+                    {
+                        "name": "query",
+                        "in": "query",
+                        "description": "Search query. Servers must support an empty query and return all the data to allow clients to properly access all the media information for offline sync.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "artistCount",
+                        "in": "query",
+                        "description": "Maximum number of artists to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "artistOffset",
+                        "in": "query",
+                        "description": "Search result offset for artists. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "albumCount",
+                        "in": "query",
+                        "description": "Maximum number of albums to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "albumOffset",
+                        "in": "query",
+                        "description": "Search result offset for albums. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "songCount",
+                        "in": "query",
+                        "description": "Maximum number of songs to return.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "songOffset",
+                        "in": "query",
+                        "description": "Search result offset for songs. Used for paging.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Search3Response"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "search3",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search3/"
+                }
+            },
+            "post": {
+                "summary": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result. (v3)",
+                "description": "Returns albums, artists and songs matching the given search criteria. Supports paging through the result.\n\nMusic is organized according to ID3 tags.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postSearch3",
+                "tags": [
+                    "Searching"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "description": "Search query. Servers must support an empty query and return all the data to allow clients to properly access all the media information for offline sync."
+                                    },
+                                    "artistCount": {
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0,
+                                        "description": "Maximum number of artists to return."
+                                    },
+                                    "artistOffset": {
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0,
+                                        "description": "Search result offset for artists. Used for paging."
+                                    },
+                                    "albumCount": {
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0,
+                                        "description": "Maximum number of albums to return."
+                                    },
+                                    "albumOffset": {
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0,
+                                        "description": "Search result offset for albums. Used for paging."
+                                    },
+                                    "songCount": {
+                                        "type": "integer",
+                                        "default": 20,
+                                        "minimum": 0,
+                                        "description": "Maximum number of songs to return."
+                                    },
+                                    "songOffset": {
+                                        "type": "integer",
+                                        "default": 0,
+                                        "minimum": 0,
+                                        "description": "Search result offset for songs. Used for paging."
+                                    },
+                                    "musicFolderId": {
+                                        "type": "string",
+                                        "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
+                                    }
+                                },
+                                "required": [
+                                    "query"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Search3Response"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "search3",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search3/"
+                }
+            }
+        },
+        "/rest/setRating": {
+            "get": {
+                "summary": "Sets the rating for a music file.",
+                "description": "Sets the rating for a music file.",
+                "operationId": "setRating",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the file (song) or folder (album/artist) to rate.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "rating",
+                        "in": "query",
+                        "description": "The rating between 1 and 5 (inclusive), or 0 to remove the rating.",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 5
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "setRating",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/setrating/"
+                }
+            },
+            "post": {
+                "summary": "Sets the rating for a music file.",
+                "description": "Sets the rating for a music file.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postSetRating",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "A string which uniquely identifies the file (song) or folder (album/artist) to rate.",
+                                        "type": "string"
+                                    },
+                                    "rating": {
+                                        "description": "The rating between 1 and 5 (inclusive), or 0 to remove the rating.",
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "maximum": 5
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "rating"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/star": {
+            "get": {
+                "summary": "Attaches a star to a song, album or artist.",
+                "description": "Attaches a star to a song, album or artist.",
+                "operationId": "star",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the file (song) or folder (album/artist) to star. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "albumId",
+                        "in": "query",
+                        "description": "The ID of an album to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "artistId",
+                        "in": "query",
+                        "description": "The ID of an artist to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "star",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/star/"
+                }
+            },
+            "post": {
+                "summary": "Attaches a star to a song, album or artist.",
+                "description": "Attaches a star to a song, album or artist.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postStar",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "The ID of the file (song) or folder (album/artist) to star. Multiple parameters allowed."
+                                    },
+                                    "albumId": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "The ID of an album to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed."
+                                    },
+                                    "artistId": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "The ID of an artist to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "star",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/star/"
+                }
+            }
+        },
+        "/rest/startScan": {
+            "get": {
+                "summary": "Initiates a rescan of the media libraries.",
+                "description": "Initiates a rescan of the media libraries. Takes no extra parameters.",
+                "operationId": "startScan",
+                "tags": [
+                    "Media Library Scanning"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StartScanResponse"
+                                }
+                            }
+                        }
+                    }
+                },
+                "externalDocs": {
+                    "description": "startScan",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/startscan/"
+                }
+            },
+            "post": {
+                "summary": "Initiates a rescan of the media libraries.",
+                "description": "Initiates a rescan of the media libraries. Takes no extra parameters.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postStartScan",
+                "tags": [
+                    "Media Library Scanning"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/StartScanResponse"
+                                }
+                            }
+                        }
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "startScan",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/startscan/"
+                }
+            }
+        },
+        "/rest/stream": {
+            "get": {
+                "summary": "Streams a given media file.",
+                "description": "Streams a given media file.\n\nOpenSubsonic servers must not count access to this endpoint as a play and increase playcount. Clients can use the Scrobble endpoint to indicate that a media is played ensuring proper data in all cases.\n\nIf the server support the Transcode Offet extension, then it must accept the timeOffset parameter for music too.",
+                "operationId": "stream",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A string which uniquely identifies the file to stream. Obtained by calls to getMusicDirectory.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "maxBitRate",
+                        "in": "query",
+                        "description": "(Since 1.2.0) If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If set to zero, no limit is imposed.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "format",
+                        "in": "query",
+                        "description": "(Since 1.6.0) Specifies the preferred target format (e.g., “mp3” or “flv”) in case there are multiple applicable transcodings. Starting with 1.9.0 you can use the special value “raw” to disable transcoding.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "timeOffset",
+                        "in": "query",
+                        "description": "By default only applicable to video streaming. If specified, start streaming at the given offset (in seconds) into the media. The `Transcode Offset` extension enables the parameter to music too.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "name": "size",
+                        "in": "query",
+                        "description": "(Since 1.6.0) Only applicable to video streaming. Requested video size specified as WxH, for instance “640x480”.",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "pattern": "^[0-9]+x[0-9]+$"
+                        }
+                    },
+                    {
+                        "name": "estimateContentLength",
+                        "in": "query",
+                        "description": "(Since 1.8.0). If set to “true”, the Content-Length HTTP header will be set to an estimated value for transcoded or downsampled media.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "converted",
+                        "in": "query",
+                        "description": "(Since 1.14.0) Only applicable to video streaming. Servers can optimize videos for streaming by converting them to MP4. If a conversion exists for the video in question, then setting this parameter to “true” will cause the converted video to be returned instead of the original.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "stream",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/stream/"
+                }
+            },
+            "post": {
+                "summary": "Streams a given media file.",
+                "description": "Streams a given media file.\n\nOpenSubsonic servers must not count access to this endpoint as a play and increase playcount. Clients can use the Scrobble endpoint to indicate that a media is played ensuring proper data in all cases.\n\nIf the server supports the Transcode Offset extension, then it must accept the timeOffset parameter for music too.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postStream",
+                "tags": [
+                    "Media Retrieval"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "A string which uniquely identifies the file to stream. Obtained by calls to getMusicDirectory."
+                                    },
+                                    "maxBitRate": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "(Since 1.2.0) If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If set to zero, no limit is imposed."
+                                    },
+                                    "format": {
+                                        "type": "string",
+                                        "description": "(Since 1.6.0) Specifies the preferred target format (e.g., “mp3” or “flv”) in case there are multiple applicable transcodings. Starting with 1.9.0 you can use the special value “raw” to disable transcoding."
+                                    },
+                                    "timeOffset": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "description": "By default only applicable to video streaming. If specified, start streaming at the given offset (in seconds) into the media. The `Transcode Offset` extension enables the parameter to music too."
+                                    },
+                                    "size": {
+                                        "type": "string",
+                                        "pattern": "^[0-9]+x[0-9]+$",
+                                        "description": "(Since 1.6.0) Only applicable to video streaming. Requested video size specified as WxH, for instance “640x480”."
+                                    },
+                                    "estimateContentLength": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "(Since 1.8.0). If set to “true”, the Content-Length HTTP header will be set to an estimated value for transcoded or downsampled media."
+                                    },
+                                    "converted": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "(Since 1.14.0) Only applicable to video streaming. Servers can optimize videos for streaming by converting them to MP4. If a conversion exists for the video in question, then setting this parameter to “true” will cause the converted video to be returned instead of the original."
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/BinaryResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        },
+        "/rest/tokenInfo": {
+            "get": {
+                "summary": "Returns information about an API key",
+                "description": "OpenSubsonic extension name `apiKeyAuthentication` (As returned by `getOpenSubsonicExtensions`). Returns data about an API key.",
+                "operationId": "tokenInfo",
+                "tags": [
+                    "System"
+                ],
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetTokenInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "tokenInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/tokeninfo/"
+                }
+            },
+            "post": {
+                "summary": "Returns information about an API key",
+                "description": "OpenSubsonic extension name `apiKeyAuthentication` (As returned by `getOpenSubsonicExtensions`). Returns data about an API key.",
+                "operationId": "postTokenInfo",
+                "tags": [
+                    "System"
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successful or failed response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GetTokenInfoResponse"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Extension not supported"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "tokenInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/tokeninfo/"
+                }
+            }
+        },
+        "/rest/unstar": {
+            "get": {
+                "summary": "Removes a star to a song, album or artist.",
+                "description": "Removes a star to a song, album or artist.",
+                "operationId": "unstar",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the file (song) or folder (album/artist) to star. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "albumId",
+                        "in": "query",
+                        "description": "The ID of an album to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "artistId",
+                        "in": "query",
+                        "description": "The ID of an artist to star. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "unstar",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/unstar/"
+                }
+            },
+            "post": {
+                "summary": "Removes a star to a song, album or artist.",
+                "description": "Removes a star to a song, album or artist.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postUnstar",
+                "tags": [
+                    "Media Annotation"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "The ID of the file (song) or folder (album/artist) to unstar. Multiple parameters allowed."
+                                    },
+                                    "albumId": {
+                                        "description": "The ID of an album to unstar. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed."
+                                    },
+                                    "artistId": {
+                                        "description": "The ID of an artist to unstar. Use this rather than `id` if the client accesses the media collection according to ID3 tags rather than file structure. Multiple parameters allowed."
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "unstar",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/unstar/"
+                }
+            }
+        },
+        "/rest/updateInternetRadioStation": {
+            "get": {
+                "summary": "Updates an existing internet radio station.",
+                "description": "Updates an existing internet radio station. Only users with admin privileges are allowed to call this method.",
+                "operationId": "updateInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "The ID of the station.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "streamUrl",
+                        "in": "query",
+                        "description": "The stream URL for the station.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "The user-defined name for the station.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "homepageUrl",
+                        "in": "query",
+                        "description": "The home page URL for the station.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updateInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateinternetradiostation/"
+                }
+            },
+            "post": {
+                "summary": "Updates an existing internet radio station.",
+                "description": "Updates an existing internet radio station. Only users with admin privileges are allowed to call this method.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postUpdateInternetRadioStation",
+                "tags": [
+                    "Internet Radio"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "The ID of the station."
+                                    },
+                                    "streamUrl": {
+                                        "type": "string",
+                                        "description": "The stream URL for the station."
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "description": "The user-defined name for the station."
+                                    },
+                                    "homepageUrl": {
+                                        "type": "string",
+                                        "description": "The home page URL for the station."
+                                    }
+                                },
+                                "required": [
+                                    "id",
+                                    "streamUrl",
+                                    "name"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updateInternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateinternetradiostation/"
+                }
+            }
+        },
+        "/rest/updatePlaylist": {
+            "get": {
+                "summary": "Updates a playlist. Only the owner of a playlist is allowed to update it.",
+                "description": "Updates a playlist. Only the owner of a playlist is allowed to update it.",
+                "operationId": "updatePlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "parameters": [
+                    {
+                        "name": "playlistId",
+                        "in": "query",
+                        "description": "The playlist ID.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "name",
+                        "in": "query",
+                        "description": "The human-readable name of the playlist.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "comment",
+                        "in": "query",
+                        "description": "The playlist comment.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "public",
+                        "in": "query",
+                        "description": "`true` if the playlist should be visible to all users, `false` otherwise.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "name": "songIdToAdd",
+                        "in": "query",
+                        "description": "Add this song with this ID to the playlist. Multiple parameters allowed.",
+                        "explode": true,
+                        "style": "form",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "songIndexToRemove",
+                        "in": "query",
+                        "description": "Remove the song at this position in the playlist. Multiple parameters allowed.",
+                        "explode": true,
+                        "style": "form",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updatePlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateplaylist/"
+                }
+            },
+            "post": {
+                "summary": "Updates a playlist. Only the owner of a playlist is allowed to update it.",
+                "description": "Updates a playlist. Only the owner of a playlist is allowed to update it.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postUpdatePlaylist",
+                "tags": [
+                    "Playlists"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "playlistId": {
+                                        "description": "The playlist ID.",
+                                        "type": "string"
+                                    },
+                                    "name": {
+                                        "description": "The human-readable name of the playlist.",
+                                        "type": "string"
+                                    },
+                                    "comment": {
+                                        "description": "The playlist comment.",
+                                        "type": "string"
+                                    },
+                                    "public": {
+                                        "description": "`true` if the playlist should be visible to all users, `false` otherwise.",
+                                        "type": "boolean"
+                                    },
+                                    "songIdToAdd": {
+                                        "description": "Add this song with this ID to the playlist. Multiple parameters allowed.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "songIndexToRemove": {
+                                        "description": "Remove the song at this position in the playlist. Multiple parameters allowed.",
+                                        "type": "array",
+                                        "items": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "playlistId"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updatePlaylist",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateplaylist/"
+                }
+            }
+        },
+        "/rest/updateShare": {
+            "get": {
+                "summary": "Updates the description and/or expiration date for an existing share.",
+                "description": "Updates the description and/or expiration date for an existing share.",
+                "operationId": "updateShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "ID of the share to update.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "description",
+                        "in": "query",
+                        "description": "A user-defined description that will be displayed to people visiting the shared media.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "expires",
+                        "in": "query",
+                        "description": "The time at which the share expires. Given as milliseconds since 1970, or zero to remove the expiration.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updateShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateshare/"
+                }
+            },
+            "post": {
+                "summary": "Updates the description and/or expiration date for an existing share.",
+                "description": "Updates the description and/or expiration date for an existing share.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postUpdateShare",
+                "tags": [
+                    "Sharing"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "description": "ID of the share to update.",
+                                        "type": "string"
+                                    },
+                                    "description": {
+                                        "description": "A user-defined description that will be displayed to people visiting the shared media.",
+                                        "type": "string"
+                                    },
+                                    "expires": {
+                                        "description": "The time at which the share expires. Given as milliseconds since 1970, or zero to remove the expiration.",
+                                        "type": "integer",
+                                        "minimum": 0
+                                    }
+                                },
+                                "required": [
+                                    "id"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updateShare",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateshare/"
+                }
+            }
+        },
+        "/rest/updateUser": {
+            "get": {
+                "summary": "Modifies an existing user on the server.",
+                "description": "Modifies an existing user on the server.",
+                "operationId": "updateUser",
+                "tags": [
+                    "User Management"
+                ],
+                "parameters": [
+                    {
+                        "name": "username",
+                        "in": "query",
+                        "description": "The name of the user.",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "password",
+                        "in": "query",
+                        "description": "The password of the user, either in clear text of hex-encoded (see above).",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "email",
+                        "in": "query",
+                        "description": "The email address of the user.",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ldapAuthenticated",
+                        "in": "query",
+                        "description": "Whether the user is authenicated in LDAP.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "adminRole",
+                        "in": "query",
+                        "description": "Whether the user is administrator.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "settingsRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to change personal settings and password.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "name": "streamRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to play files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        }
+                    },
+                    {
+                        "name": "jukeboxRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to play files in jukebox mode.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "downloadRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to download files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "uploadRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to upload files.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "coverArtRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to change cover art and tags.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "commentRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to create and edit comments and ratings.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "podcastRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to administrate Podcasts.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "shareRole",
+                        "in": "query",
+                        "description": "Whether the user is allowed to share files with anyone.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "videoConversionRole",
+                        "in": "query",
+                        "description": "(Since 1.15.0) Whether the user is allowed to start video conversions.",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "musicFolderId",
+                        "in": "query",
+                        "description": "(Since 1.12.0) IDs of the music folders the user is allowed access to. Include the parameter once for each folder.",
+                        "required": false,
+                        "explode": true,
+                        "style": "form",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "maxBitRate",
+                        "in": "query",
+                        "description": "(Since 1.13.0) The maximum bit rate (in Kbps) for the user. Audio streams of higher bit rates are automatically downsampled to this bit rate. Legal values: 0 (no limit), 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320.",
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "enum": [
+                                0,
+                                32,
+                                40,
+                                48,
+                                56,
+                                64,
+                                80,
+                                96,
+                                112,
+                                128,
+                                160,
+                                192,
+                                224,
+                                256,
+                                320
+                            ]
+                        }
+                    },
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    }
+                },
+                "externalDocs": {
+                    "description": "updateUser",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/updateuser/"
+                }
+            },
+            "post": {
+                "summary": "Modifies an existing user on the server.",
+                "description": "Modifies an existing user on the server.\n\nRequires OpenSubsonic extension name `formPost` (As returned by `getOpenSubsonicExtensions`)",
+                "operationId": "postUpdateUser",
+                "tags": [
+                    "User Management"
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "username": {
+                                        "type": "string",
+                                        "description": "The name of the user."
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "description": "The password of the user, either in clear text or hex-encoded."
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "description": "The email address of the user."
+                                    },
+                                    "ldapAuthenticated": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is authenticated in LDAP."
+                                    },
+                                    "adminRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is an administrator."
+                                    },
+                                    "settingsRole": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Whether the user is allowed to change personal settings and password."
+                                    },
+                                    "streamRole": {
+                                        "type": "boolean",
+                                        "default": true,
+                                        "description": "Whether the user is allowed to play files."
+                                    },
+                                    "jukeboxRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to play files in jukebox mode."
+                                    },
+                                    "downloadRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to download files."
+                                    },
+                                    "uploadRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to upload files."
+                                    },
+                                    "coverArtRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to change cover art and tags."
+                                    },
+                                    "commentRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to create and edit comments and ratings."
+                                    },
+                                    "podcastRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to administrate Podcasts."
+                                    },
+                                    "shareRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "Whether the user is allowed to share files with anyone."
+                                    },
+                                    "videoConversionRole": {
+                                        "type": "boolean",
+                                        "default": false,
+                                        "description": "(Since 1.15.0) Whether the user is allowed to start video conversions."
+                                    },
+                                    "musicFolderId": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "description": "(Since 1.12.0) IDs of the music folders the user is allowed access to. Include the parameter once for each folder."
+                                    },
+                                    "maxBitRate": {
+                                        "type": "integer",
+                                        "enum": [
+                                            0,
+                                            32,
+                                            40,
+                                            48,
+                                            56,
+                                            64,
+                                            80,
+                                            96,
+                                            112,
+                                            128,
+                                            160,
+                                            192,
+                                            224,
+                                            256,
+                                            320
+                                        ],
+                                        "description": "(Since 1.13.0) The maximum bit rate (in Kbps) for the user. Audio streams of higher bit rates are automatically downsampled to this bit rate. Legal values: 0 (no limit), 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320."
+                                    }
+                                },
+                                "required": [
+                                    "username",
+                                    "password"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/f"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "$ref": "#/components/responses/EmptySubsonicResponse"
+                    },
+                    "405": {
+                        "$ref": "#/components/responses/HTTPFormPostNotSupported"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "responses": {
+            "EmptySubsonicResponse": {
+                "description": "Successful or failed response",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/SubsonicResponse"
+                        }
+                    }
+                }
+            },
+            "HTTPFormPostNotSupported": {
+                "description": "HTTP form POST (`formPost`) Extension not supported"
+            },
+            "BinaryResponse": {
+                "description": "Success (binary) or error (xml) response",
+                "content": {
+                    "application/binary": {
+                        "schema": {
+                            "type": "string",
+                            "format": "binary"
+                        }
+                    },
+                    "text/xml": {
+                        "schema": {
+                            "type": "object",
+                            "description": "Error response TODO: TO BE DESCRIBED"
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "f": {
+                "name": "f",
+                "description": "The response format. Must be 'xml' or 'json'. For the purposes of this document, only `json` is allowed.",
+                "in": "query",
+                "required": true,
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "json"
+                    ]
+                }
+            }
+        },
+        "securitySchemes": {
+            "apiKeyAuth": {
+                "type": "apiKey",
+                "name": "apiKey",
+                "in": "query",
+                "description": "[OS] An API key used for authentication. If specified, `p`, `t`, `s` nor `u` can be specified."
+            },
+            "username": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "u",
+                "description": "The username."
+            },
+            "legacyPassword": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "p",
+                "description": "The password, either in clear text or hex-encoded with a “enc:” prefix. Since 1.13.0 this should only be used for testing purposes. `u` must be specified."
+            },
+            "token": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "t",
+                "description": "(Since 1.13.0) The authentication token computed as md5(password + salt). `u` and `s` must be specified. See https://opensubsonic.netlify.app/docs/api-reference/#authentication for details."
+            },
+            "salt": {
+                "type": "apiKey",
+                "in": "query",
+                "name": "s",
+                "description": "(Since 1.13.0) A random string (“salt”) used as input for computing the password hash. `u` and `t` must be specified. See https://opensubsonic.netlify.app/docs/api-reference/#authentication for details."
+            },
+            "protocolVersion": {
+                "type": "apiKey",
+                "name": "v",
+                "description": "The protocol version implemented by the client, i.e., the version of the subsonic-rest-api.xsd schema used (see below).",
+                "in": "query"
+            },
+            "clientName": {
+                "type": "apiKey",
+                "name": "c",
+                "description": "A unique string identifying the client application.",
+                "in": "query"
+            }
+        },
+        "schemas": {
+            "SubsonicError": {
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "enum": [
+                            0,
+                            10,
+                            20,
+                            30,
+                            40,
+                            41,
+                            42,
+                            43,
+                            44,
+                            50,
+                            60,
+                            70
+                        ],
+                        "description": "The error code.\n* 0: A generic error.\n* 10: Required parameter is missing.\n* 20: Incompatible Subsonic REST protocol version. Client must upgrade.\n* 30: Incompatible Subsonic REST protocol version. Server must upgrade.\n* 40: Wrong username or password.\n* 41: Token authentication not supported for LDAP users.\n* 42: Provided authentication mechanism not supported.\n* 43: Multiple conflicting authentication mechanisms provided.\n* 44: Invalid API key.\n* 50: User is not authorized for the given operation.\n* 60: The trial period for the Subsonic server is over. Please upgrade to Subsonic Premium. Visit subsonic.org for details.\n* 70: The requested data was not found."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The optional error message"
+                    },
+                    "helpUrl": {
+                        "type": "string",
+                        "description": "A URL (documentation, configuration, etc) which may provide additional context for the error)"
+                    }
+                },
+                "required": [
+                    "code"
+                ],
+                "example": {
+                    "code": 42,
+                    "message": "Authentication mechanism not supported. Use API keys",
+                    "helpUrl": "https://example.org/users/apiKey"
+                },
+                "externalDocs": {
+                    "description": "Error",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/error/"
+                }
+            },
+            "SubsonicBaseResponse": {
+                "type": "object",
+                "properties": {
+                    "version": {
+                        "type": "string",
+                        "description": "The server supported Subsonic API version."
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The server actual name. [Ex: Navidrome or gonic]"
+                    },
+                    "serverVersion": {
+                        "type": "string",
+                        "description": "The server version."
+                    },
+                    "openSubsonic": {
+                        "type": "boolean",
+                        "description": "Must return true if the server support OpenSubsonic API v1"
+                    }
+                },
+                "required": [
+                    "version",
+                    "type",
+                    "serverVersion",
+                    "openSubsonic"
+                ]
+            },
+            "SubsonicSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicBaseResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "description": "The status of the request. [Ex: success]",
+                                "enum": [
+                                    "success"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "status"
+                        ],
+                        "example": {
+                            "status": "ok",
+                            "version": "1.16.1",
+                            "type": "AwesomeServerName",
+                            "serverVersion": "0.1.3 (tag)",
+                            "openSubsonic": true
+                        },
+                        "externalDocs": {
+                            "description": "SubsonicResponse",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/subsonic-response/"
+                        }
+                    }
+                ]
+            },
+            "SubsonicFailureResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicBaseResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "status": {
+                                "type": "string",
+                                "description": "The status of the request. [Ex: failed]",
+                                "enum": [
+                                    "failed"
+                                ]
+                            },
+                            "error": {
+                                "$ref": "#/components/schemas/SubsonicError"
+                            }
+                        },
+                        "required": [
+                            "status",
+                            "error"
+                        ],
+                        "externalDocs": {
+                            "description": "SubsonicResponse",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/subsonic-response/"
+                        }
+                    }
+                ]
+            },
+            "SubsonicResponse": {
+                "type": "object",
+                "description": "Common answer wrapper.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "SubsonicResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/subsonic-response/"
+                }
+            },
+            "ItemGenre": {
+                "type": "object",
+                "description": "A genre returned in list of genres for an item.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Genre name"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "externalDocs": {
+                    "description": "ItemGenre",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/itemgenre/"
+                }
+            },
+            "ArtistID3": {
+                "type": "object",
+                "description": "An artist from ID3 tags.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The id of the artist"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The artist name."
+                    },
+                    "coverArt": {
+                        "type": "string",
+                        "description": "A covertArt id."
+                    },
+                    "artistImageUrl": {
+                        "type": "string",
+                        "description": "An url to an external image source."
+                    },
+                    "albumCount": {
+                        "type": "integer",
+                        "description": "Artist album count."
+                    },
+                    "starred": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the artist was starred. [ISO 8601]"
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "The artist MusicBrainzID."
+                    },
+                    "sortName": {
+                        "type": "string",
+                        "description": "The artist sort name."
+                    },
+                    "roles": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "The list of all roles this artist has in the library."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "externalDocs": {
+                    "description": "ArtistID3",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/artistid3/"
+                }
+            },
+            "Contributor": {
+                "type": "object",
+                "description": "A contributor artist for a song or an album",
+                "properties": {
+                    "role": {
+                        "type": "string",
+                        "description": "The contributor role."
+                    },
+                    "subRole": {
+                        "type": "string",
+                        "description": "The subRole for roles that may require it. Ex: The instrument for the performer role (TMCL/performer tags). Note: For consistency between different tag formats, the TIPL sub roles should be directly exposed in the role field."
+                    },
+                    "artist": {
+                        "$ref": "#/components/schemas/ArtistID3"
+                    }
+                },
+                "required": [
+                    "role",
+                    "artist"
+                ],
+                "externalDocs": {
+                    "description": "Contributor",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/contributor/"
+                }
+            },
+            "ReplayGain": {
+                "type": "object",
+                "description": "The replay gain data of a song. Note: If the data is not present the field must be ommited in the answer. (But the replayGain field on Child must always be present)",
+                "properties": {
+                    "trackGain": {
+                        "type": "number",
+                        "description": "The track replay gain value. (In Db)"
+                    },
+                    "albumGain": {
+                        "type": "number",
+                        "description": "The album replay gain value. (In Db)"
+                    },
+                    "trackPeak": {
+                        "type": "number",
+                        "description": "The track peak value. (Must be positive)",
+                        "minimum": 0
+                    },
+                    "albumPeak": {
+                        "type": "number",
+                        "description": "The album peak value. (Must be positive)",
+                        "minimum": 0
+                    },
+                    "baseGain": {
+                        "type": "number",
+                        "description": "The base gain value. (In Db) (Ogg Opus Output Gain for example)"
+                    },
+                    "fallbackGain": {
+                        "type": "number",
+                        "description": "An optional fallback gain that clients should apply when the corresponding gain value is missing. (Can be computed from the tracks or exposed as an user setting.)"
+                    }
+                },
+                "externalDocs": {
+                    "description": "Replay Gain",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/replaygain/"
+                }
+            },
+            "GenericMediaType": {
+                "type": "string",
+                "enum": [
+                    "music",
+                    "video",
+                    "podcast",
+                    "audiobook"
+                ],
+                "description": "The generic type of media [music/podcast/audiobook/video]"
+            },
+            "MediaType": {
+                "type": "string",
+                "enum": [
+                    "song",
+                    "album",
+                    "artist"
+                ],
+                "description": "Note: If you support `musicBrainzId` you must support this field to ensure clients knows what the ID refers to."
+            },
+            "ExplicitStatus": {
+                "type": "string",
+                "enum": [
+                    "clean",
+                    "explicit",
+                    ""
+                ],
+                "description": "Returns “explicit”, “clean” or “”. (For songs extracted from tags “ITUNESADVISORY”: 1 = explicit, 2 = clean, MP4 “rtng”: 1 or 4 = explicit, 2 = clean. See `albumID3` for albums)"
+            },
+            "Child": {
+                "type": "object",
+                "description": "A media.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The id of the media."
+                    },
+                    "parent": {
+                        "type": "string",
+                        "description": "The id of the parent (folder/album)"
+                    },
+                    "isDir": {
+                        "type": "boolean",
+                        "description": "The media is a directory"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "The media name."
+                    },
+                    "album": {
+                        "type": "string",
+                        "description": "The album name."
+                    },
+                    "artist": {
+                        "type": "string",
+                        "description": "The artist name."
+                    },
+                    "track": {
+                        "type": "integer",
+                        "description": "The track number."
+                    },
+                    "year": {
+                        "type": "integer",
+                        "description": "The media year."
+                    },
+                    "genre": {
+                        "type": "string",
+                        "description": "The media genre"
+                    },
+                    "coverArt": {
+                        "type": "string",
+                        "description": "The coverArt id."
+                    },
+                    "size": {
+                        "type": "integer",
+                        "description": "A file size of the media."
+                    },
+                    "contentType": {
+                        "type": "string",
+                        "description": "The mimeType of the media."
+                    },
+                    "suffix": {
+                        "type": "string",
+                        "description": "The file suffix of the media."
+                    },
+                    "transcodedContentType": {
+                        "type": "string",
+                        "description": "The transcoded mediaType if transcoding should happen."
+                    },
+                    "transcodedSuffix": {
+                        "type": "string",
+                        "description": "The file suffix of the transcoded media."
+                    },
+                    "duration": {
+                        "type": "integer",
+                        "description": "The duration of the media in seconds."
+                    },
+                    "bitRate": {
+                        "type": "integer",
+                        "description": "The bitrate of the media."
+                    },
+                    "bitDepth": {
+                        "type": "integer",
+                        "description": "The bit depth of the media."
+                    },
+                    "samplingRate": {
+                        "type": "integer",
+                        "description": "The sampling rate of the media."
+                    },
+                    "channelCount": {
+                        "type": "integer",
+                        "description": "The number of channels of the media."
+                    },
+                    "path": {
+                        "type": "string",
+                        "description": "The full path of the media."
+                    },
+                    "isVideo": {
+                        "type": "boolean",
+                        "description": "Media is a video"
+                    },
+                    "userRating": {
+                        "type": "integer",
+                        "description": "The user rating of the media [1-5]",
+                        "minimum": 1,
+                        "maximum": 5
+                    },
+                    "averageRating": {
+                        "type": "number",
+                        "description": "The average rating of the media [1.0-5.0]",
+                        "minimum": 0,
+                        "maximum": 5
+                    },
+                    "playCount": {
+                        "type": "integer",
+                        "description": "The play count."
+                    },
+                    "discNumber": {
+                        "type": "integer",
+                        "description": "The disc number."
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the media was created. [ISO 8601]"
+                    },
+                    "starred": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the media was starred. [ISO 8601]"
+                    },
+                    "albumId": {
+                        "type": "string",
+                        "description": "The corresponding album id"
+                    },
+                    "artistId": {
+                        "type": "string",
+                        "description": "The corresponding artist id"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/GenericMediaType"
+                    },
+                    "mediaType": {
+                        "$ref": "#/components/schemas/MediaType"
+                    },
+                    "bookmarkPosition": {
+                        "type": "integer",
+                        "description": "The bookmark position in seconds"
+                    },
+                    "originalWidth": {
+                        "type": "integer",
+                        "description": "The video original Width"
+                    },
+                    "originalHeight": {
+                        "type": "integer",
+                        "description": "The video original Height"
+                    },
+                    "played": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the album was last played. [ISO 8601]"
+                    },
+                    "bpm": {
+                        "type": "integer",
+                        "description": "The BPM of the song."
+                    },
+                    "comment": {
+                        "type": "string",
+                        "description": "The comment tag of the song."
+                    },
+                    "sortName": {
+                        "type": "string",
+                        "description": "The song sort name."
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "The track MusicBrainzID."
+                    },
+                    "genres": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ItemGenre"
+                        },
+                        "description": "The list of all genres of the song."
+                    },
+                    "artists": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        },
+                        "description": "The list of all song artists of the song. (Note: Only the required `ArtistID3` fields should be returned by default)"
+                    },
+                    "displayArtist": {
+                        "type": "string",
+                        "description": "The single value display artist."
+                    },
+                    "albumArtists": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        },
+                        "description": "The list of all album artists of the song. (Note: Only the required `ArtistID3` fields should be returned by default)"
+                    },
+                    "displayAlbumArtist": {
+                        "type": "string",
+                        "description": "The single value display album artist."
+                    },
+                    "contributors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Contributor"
+                        },
+                        "description": "The list of all contributor artists of the song."
+                    },
+                    "displayComposer": {
+                        "type": "string",
+                        "description": "The single value display composer."
+                    },
+                    "moods": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "The list of all moods of the song."
+                    },
+                    "replayGain": {
+                        "$ref": "#/components/schemas/ReplayGain",
+                        "description": "The replay gain data of the song."
+                    },
+                    "explicitStatus": {
+                        "$ref": "#/components/schemas/ExplicitStatus"
+                    }
+                },
+                "required": [
+                    "id",
+                    "isDir",
+                    "title"
+                ],
+                "externalDocs": {
+                    "description": "Child",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/child/"
+                }
+            },
+            "Playlist": {
+                "type": "object",
+                "description": "Playlist.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Id of the playlist"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Name of the playlist"
+                    },
+                    "comment": {
+                        "type": "string",
+                        "description": "A comment"
+                    },
+                    "owner": {
+                        "type": "string",
+                        "description": "Owner of the playlist"
+                    },
+                    "public": {
+                        "type": "boolean",
+                        "description": "Is the playlist public"
+                    },
+                    "songCount": {
+                        "type": "integer",
+                        "description": "number of songs"
+                    },
+                    "duration": {
+                        "type": "integer",
+                        "description": "Playlist duration in seconds"
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date [ISO 8601]"
+                    },
+                    "changed": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Last changed date [ISO 8601]"
+                    },
+                    "coverArt": {
+                        "type": "string",
+                        "description": "A cover Art Id"
+                    },
+                    "allowedUser": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "A list of allowed usernames"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "songCount",
+                    "duration",
+                    "created",
+                    "changed"
+                ],
+                "externalDocs": {
+                    "description": "Playlist",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/playlist/"
+                }
+            },
+            "PlaylistWithSongs": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Playlist"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "entry": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/Child"
+                                },
+                                "description": "The list of songs"
+                            }
+                        },
+                        "externalDocs": {
+                            "description": "PlaylistWithSongs",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/playlistwithsongs/"
+                        }
+                    }
+                ]
+            },
+            "CreatePlaylistSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "playlist": {
+                                "$ref": "#/components/schemas/PlaylistWithSongs"
+                            }
+                        },
+                        "required": [
+                            "playlist"
+                        ]
+                    }
+                ]
+            },
+            "CreatePlaylistResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested playlist element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/CreatePlaylistSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "CreatePlaylistResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createplaylist/"
+                }
+            },
+            "Share": {
+                "type": "object",
+                "description": "Share.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The share Id"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "The share url"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "The username"
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Creation date [ISO 8601]"
+                    },
+                    "expires": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Share expiration [ISO 8601]"
+                    },
+                    "lastVisited": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Last visit [ISO 8601]"
+                    },
+                    "visitCount": {
+                        "type": "integer",
+                        "description": "Visit count"
+                    },
+                    "entry": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "A list of share"
+                    }
+                },
+                "required": [
+                    "id",
+                    "url",
+                    "username",
+                    "created",
+                    "visitCount"
+                ],
+                "externalDocs": {
+                    "description": "Share",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/share/"
+                }
+            },
+            "Shares": {
+                "type": "object",
+                "description": "Shares.",
+                "properties": {
+                    "share": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Share"
+                        },
+                        "description": "A list of share"
+                    }
+                },
+                "externalDocs": {
+                    "description": "Shares",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/shares/"
+                }
+            },
+            "CreateSharesSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "shares": {
+                                "$ref": "#/components/schemas/Shares"
+                            }
+                        },
+                        "required": [
+                            "shares"
+                        ]
+                    }
+                ]
+            },
+            "CreateSharesResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested shares element on success. Which in turns contains a single share element for the newly created share",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/CreateSharesSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "CreateSharesResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/createshare/"
+                }
+            },
+            "RecordLabel": {
+                "type": "object",
+                "description": "A record label for an album.",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "externalDocs": {
+                    "description": "RecordLabel",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/recordlabel/"
+                }
+            },
+            "ItemDate": {
+                "type": "object",
+                "description": "A date for a media item that may be just a year, or year-month, or full date.",
+                "properties": {
+                    "year": {
+                        "type": "integer",
+                        "description": "The year"
+                    },
+                    "month": {
+                        "type": "integer",
+                        "description": "The month (1-12)",
+                        "minimum": 1,
+                        "maximum": 12
+                    },
+                    "day": {
+                        "type": "integer",
+                        "description": "The day (1-31)",
+                        "minimum": 1,
+                        "maximum": 31
+                    }
+                },
+                "externalDocs": {
+                    "description": "ItemDate",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/itemdate/"
+                }
+            },
+            "DiscTitle": {
+                "type": "object",
+                "description": "A disc title for an album",
+                "properties": {
+                    "disc": {
+                        "type": "integer",
+                        "description": "The disc number."
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "The name of the disc."
+                    }
+                },
+                "required": [
+                    "disc",
+                    "title"
+                ],
+                "externalDocs": {
+                    "description": "DiscTitle",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/disctitle/"
+                }
+            },
+            "AlbumID3": {
+                "type": "object",
+                "description": "Album with songs.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The id of the album"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The album name."
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "The album version name (Remastered, Anniversary Box Set, …)."
+                    },
+                    "artist": {
+                        "type": "string",
+                        "description": "Artist name."
+                    },
+                    "artistId": {
+                        "type": "string",
+                        "description": "The id of the artist"
+                    },
+                    "coverArt": {
+                        "type": "string",
+                        "description": "A covertArt id."
+                    },
+                    "songCount": {
+                        "type": "integer",
+                        "description": "Number of songs"
+                    },
+                    "duration": {
+                        "type": "integer",
+                        "description": "Total duration of the album in seconds"
+                    },
+                    "playCount": {
+                        "type": "integer",
+                        "description": "Number of play of the album"
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the album was added. [ISO 8601]"
+                    },
+                    "starred": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the album was added. [ISO 8601]"
+                    },
+                    "year": {
+                        "type": "integer",
+                        "description": "The album year"
+                    },
+                    "genre": {
+                        "type": "string",
+                        "description": "The album genre"
+                    },
+                    "played": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date the album was last played. [ISO 8601]"
+                    },
+                    "userRating": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "The user rating of the album. [1-5]"
+                    },
+                    "recordLabels": {
+                        "type": "array",
+                        "description": "The labels producing the album.",
+                        "items": {
+                            "$ref": "#/components/schemas/RecordLabel"
+                        }
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "The album MusicBrainzID."
+                    },
+                    "genres": {
+                        "type": "array",
+                        "description": "The list of all genres of the album.",
+                        "items": {
+                            "$ref": "#/components/schemas/ItemGenre"
+                        }
+                    },
+                    "artists": {
+                        "type": "array",
+                        "description": "The list of all album artists of the album.",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        }
+                    },
+                    "displayArtist": {
+                        "type": "string",
+                        "description": "The single value display artist."
+                    },
+                    "releaseTypes": {
+                        "type": "array",
+                        "description": "The types of this album release. (Album, Compilation, EP, Remix, …).",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "moods": {
+                        "type": "array",
+                        "description": "The list of all moods of the album.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "sortName": {
+                        "type": "string",
+                        "description": "The album sort name."
+                    },
+                    "originalReleaseDate": {
+                        "$ref": "#/components/schemas/ItemDate",
+                        "description": "Date the album was originally released."
+                    },
+                    "releaseDate": {
+                        "$ref": "#/components/schemas/ItemDate",
+                        "description": "Date the specific edition of the album was released. Note: for files using ID3 tags, releaseDate should generally be read from the TDRL tag. Servers that use a different source for this field should document the behavior."
+                    },
+                    "isCompilation": {
+                        "type": "boolean",
+                        "description": "True if the album is a compilation."
+                    },
+                    "explicitStatus": {
+                        "$ref": "#/components/schemas/ExplicitStatus"
+                    },
+                    "discTitles": {
+                        "type": "array",
+                        "description": "The list of all disc titles of the album.",
+                        "items": {
+                            "$ref": "#/components/schemas/DiscTitle"
+                        }
+                    },
+                    "song": {
+                        "type": "array",
+                        "description": "The list of songs",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        }
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "songCount",
+                    "duration",
+                    "created"
+                ],
+                "externalDocs": {
+                    "description": "AlbumID3",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/albumid3/"
+                }
+            },
+            "AlbumID3WithSongs": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/AlbumID3"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "song": {
+                                "type": "array",
+                                "description": "The list of songs",
+                                "items": {
+                                    "$ref": "#/components/schemas/Child"
+                                }
+                            }
+                        },
+                        "required": [
+                            "song"
+                        ],
+                        "externalDocs": {
+                            "description": "AlbumID3WithSongs",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/albumid3withsongs/"
+                        }
+                    }
+                ]
+            },
+            "GetAlbumSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "album": {
+                                "$ref": "#/components/schemas/AlbumID3WithSongs"
+                            }
+                        },
+                        "required": [
+                            "album"
+                        ]
+                    }
+                ]
+            },
+            "GetAlbumResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested album element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetAlbumSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetAlbumResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbum/"
+                }
+            },
+            "AlbumInfo": {
+                "type": "object",
+                "description": "Album info.",
+                "properties": {
+                    "notes": {
+                        "type": "string",
+                        "description": "Album notes"
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "Album musicBrainzId"
+                    },
+                    "lastFmUrl": {
+                        "type": "string",
+                        "description": "Album lastFmUrl"
+                    },
+                    "smallImageUrl": {
+                        "type": "string",
+                        "description": "Album smallImageUrl"
+                    },
+                    "mediumImageUrl": {
+                        "type": "string",
+                        "description": "Album mediumImageUrl"
+                    },
+                    "largeImageUrl": {
+                        "type": "string",
+                        "description": "Album largeImageUrl"
+                    }
+                },
+                "externalDocs": {
+                    "description": "AlbumInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/albuminfo/"
+                }
+            },
+            "GetAlbumInfoSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "albumInfo": {
+                                "$ref": "#/components/schemas/AlbumInfo"
+                            }
+                        },
+                        "required": [
+                            "albumInfo"
+                        ]
+                    }
+                ]
+            },
+            "GetAlbumInfoResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested albumInfo element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetAlbumInfoSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetAlbumInfoResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbuminfo/"
+                }
+            },
+            "AlbumListType": {
+                "type": "string",
+                "description": "The list type. Must be one of the following: random, newest, highest, frequent, recent. Since 1.8.0 you can also use alphabeticalByName or alphabeticalByArtist to page through all albums alphabetically, and starred to retrieve starred albums. Since 1.10.1 you can use byYear and byGenre to list albums in a given year range or genre.",
+                "enum": [
+                    "random",
+                    "newest",
+                    "highest",
+                    "frequent",
+                    "recent",
+                    "alphabeticalByName",
+                    "alphabeticalByArtist",
+                    "starred",
+                    "byYear",
+                    "byGenre"
+                ]
+            },
+            "AlbumList": {
+                "type": "object",
+                "description": "Album list.",
+                "properties": {
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Artist albums"
+                    }
+                },
+                "externalDocs": {
+                    "description": "AlbumList",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/albumlist/"
+                }
+            },
+            "GetAlbumListSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "albumList": {
+                                "$ref": "#/components/schemas/AlbumList"
+                            }
+                        },
+                        "required": [
+                            "albumList"
+                        ]
+                    }
+                ]
+            },
+            "GetAlbumListResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested albumList element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetAlbumListSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetAlbumListResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist/"
+                }
+            },
+            "AlbumList2": {
+                "type": "object",
+                "properties": {
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AlbumID3"
+                        },
+                        "description": "Artist albums",
+                        "externalDocs": {
+                            "description": "AlbumList2",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/albumlist2/"
+                        }
+                    }
+                }
+            },
+            "GetAlbumList2SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "albumList2": {
+                                "$ref": "#/components/schemas/AlbumList"
+                            }
+                        },
+                        "required": [
+                            "albumList2"
+                        ]
+                    }
+                ]
+            },
+            "GetAlbumList2Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested albumList2 element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetAlbumList2SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetAlbumList2Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getalbumlist2/"
+                }
+            },
+            "ArtistWithAlbumsID3": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/ArtistID3"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "album": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/AlbumID3"
+                                },
+                                "description": "Artist albums"
+                            }
+                        },
+                        "required": [
+                            "album"
+                        ],
+                        "externalDocs": {
+                            "description": "ArtistWithAlbumsID3",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/artistwithalbumsid3/"
+                        }
+                    }
+                ]
+            },
+            "GetArtistSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "artist": {
+                                "$ref": "#/components/schemas/ArtistWithAlbumsID3"
+                            }
+                        },
+                        "required": [
+                            "artist"
+                        ]
+                    }
+                ]
+            },
+            "GetArtistResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested artist element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetArtistSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetArtistResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartist/"
+                }
+            },
+            "Artist": {
+                "type": "object",
+                "description": "Artist details.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Artist id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "Artist name"
+                    },
+                    "artistImageUrl": {
+                        "type": "string",
+                        "description": "Artist image url"
+                    },
+                    "starred": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Artist starred date [ISO 8601]"
+                    },
+                    "userRating": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "Artist rating [1-5]"
+                    },
+                    "averageRating": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "Artist average rating [1.0-5.0]"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ],
+                "externalDocs": {
+                    "description": "Artist",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/artist/"
+                }
+            },
+            "ArtistInfo": {
+                "type": "object",
+                "description": "Artist info.",
+                "properties": {
+                    "biography": {
+                        "type": "string",
+                        "description": "Artist biography"
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "Artist musicBrainzId"
+                    },
+                    "lastFmUrl": {
+                        "type": "string",
+                        "description": "Artist lastFmUrl"
+                    },
+                    "smallImageUrl": {
+                        "type": "string",
+                        "description": "Artist smallImageUrl"
+                    },
+                    "mediumImageUrl": {
+                        "type": "string",
+                        "description": "Artist mediumImageUrl"
+                    },
+                    "largeImageUrl": {
+                        "type": "string",
+                        "description": "Artist largeImageUrl"
+                    },
+                    "similarArtist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Artist"
+                        },
+                        "description": "Similar artists"
+                    }
+                },
+                "externalDocs": {
+                    "description": "ArtistInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/artistinfo/"
+                }
+            },
+            "GetArtistInfoSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "artistInfo": {
+                                "$ref": "#/components/schemas/ArtistInfo"
+                            }
+                        },
+                        "required": [
+                            "artistInfo"
+                        ]
+                    }
+                ]
+            },
+            "GetArtistInfoResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested artistInfo element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetArtistInfoSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetArtistInfoResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo/"
+                }
+            },
+            "ArtistInfo2": {
+                "type": "object",
+                "description": "Artist info.",
+                "properties": {
+                    "biography": {
+                        "type": "string",
+                        "description": "Artist biography"
+                    },
+                    "musicBrainzId": {
+                        "type": "string",
+                        "description": "Artist musicBrainzId"
+                    },
+                    "lastFmUrl": {
+                        "type": "string",
+                        "description": "Artist lastFmUrl"
+                    },
+                    "smallImageUrl": {
+                        "type": "string",
+                        "description": "Artist smallImageUrl"
+                    },
+                    "mediumImageUrl": {
+                        "type": "string",
+                        "description": "Artist mediumImageUrl"
+                    },
+                    "largeImageUrl": {
+                        "type": "string",
+                        "description": "Artist largeImageUrl"
+                    },
+                    "similarArtist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        },
+                        "description": "Similar artists"
+                    }
+                },
+                "externalDocs": {
+                    "description": "ArtistInfo2",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/artistinfo2/"
+                }
+            },
+            "GetArtistInfo2SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "artistInfo2": {
+                                "$ref": "#/components/schemas/ArtistInfo2"
+                            }
+                        },
+                        "required": [
+                            "artistInfo2"
+                        ]
+                    }
+                ]
+            },
+            "GetArtistInfo2Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested artistInfo2 element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetArtistInfo2SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetArtistInfo2Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartistinfo2/"
+                }
+            },
+            "ArtistsID3": {
+                "type": "object",
+                "description": "A list of indexed Artists.",
+                "externalDocs": {
+                    "description": "ArtistsID3",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/artistsid3/"
+                },
+                "properties": {
+                    "ignoredArticles": {
+                        "type": "string",
+                        "description": "List of ignored articles space separated"
+                    },
+                    "index": {
+                        "type": "array",
+                        "description": "Index list",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        }
+                    }
+                }
+            },
+            "GetArtistsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "artists": {
+                                "$ref": "#/components/schemas/ArtistsID3"
+                            }
+                        },
+                        "required": [
+                            "artists"
+                        ]
+                    }
+                ]
+            },
+            "GetArtistsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested artists element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetArtistsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetArtistsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getartists/"
+                }
+            },
+            "Bookmark": {
+                "type": "object",
+                "description": "A bookmark.",
+                "externalDocs": {
+                    "description": "Bookmark",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/bookmark/"
+                },
+                "properties": {
+                    "position": {
+                        "type": "integer",
+                        "description": "Bookmark position in seconds"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "Username"
+                    },
+                    "comment": {
+                        "type": "string",
+                        "description": "Bookmark comment"
+                    },
+                    "created": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Bookmark creation date [ISO 8601]"
+                    },
+                    "changed": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Bookmark last updated date [ISO 8601]"
+                    },
+                    "entry": {
+                        "$ref": "#/components/schemas/Child",
+                        "description": "The bookmark file"
+                    }
+                },
+                "required": [
+                    "position",
+                    "username",
+                    "created",
+                    "changed",
+                    "entry"
+                ]
+            },
+            "Bookmarks": {
+                "type": "object",
+                "description": "Bookmarks list.",
+                "externalDocs": {
+                    "description": "Bookmarks",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/bookmarks/"
+                },
+                "properties": {
+                    "bookmark": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Bookmark"
+                        },
+                        "description": "List of bookmark"
+                    }
+                }
+            },
+            "GetBookmarksSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "bookmarks": {
+                                "$ref": "#/components/schemas/Bookmarks"
+                            }
+                        },
+                        "required": [
+                            "bookmarks"
+                        ]
+                    }
+                ]
+            },
+            "GetBookmarksResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested bookmarks element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetBookmarksSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetBookmarksResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getbookmarks/"
+                }
+            },
+            "ChatMessage": {
+                "type": "object",
+                "description": "A chatMessage.",
+                "externalDocs": {
+                    "description": "ChatMessage",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/chatmessage/"
+                },
+                "properties": {
+                    "username": {
+                        "type": "string",
+                        "description": "Username"
+                    },
+                    "time": {
+                        "type": "integer",
+                        "description": "Time in millis since Jan 1 1970"
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "The message"
+                    }
+                },
+                "required": [
+                    "id",
+                    "username",
+                    "message"
+                ]
+            },
+            "ChatMessages": {
+                "type": "object",
+                "description": "Chat messages list.",
+                "externalDocs": {
+                    "description": "ChatMessages",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/chatmessages/"
+                },
+                "properties": {
+                    "chatMessage": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ChatMessage"
+                        },
+                        "description": "List of chatMessage"
+                    }
+                }
+            },
+            "GetChatMessagesSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "chatMessages": {
+                                "$ref": "#/components/schemas/ChatMessages"
+                            }
+                        },
+                        "required": [
+                            "chatMessages"
+                        ]
+                    }
+                ]
+            },
+            "GetChatMessagesResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested chatMessages element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetChatMessagesSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetChatMessagesResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getchatmessages/"
+                }
+            },
+            "Genre": {
+                "type": "object",
+                "description": "A genre.",
+                "externalDocs": {
+                    "description": "Genre",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/genre/"
+                },
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "Genre name"
+                    },
+                    "songCount": {
+                        "type": "integer",
+                        "description": "Genre song count"
+                    },
+                    "albumCount": {
+                        "type": "integer",
+                        "description": "Genre album count"
+                    }
+                },
+                "required": [
+                    "value",
+                    "songCount",
+                    "albumCount"
+                ]
+            },
+            "Genres": {
+                "type": "object",
+                "description": "Genres list.",
+                "externalDocs": {
+                    "description": "Genres",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/genres/"
+                },
+                "properties": {
+                    "genre": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Genre"
+                        },
+                        "description": "List of genre"
+                    }
+                }
+            },
+            "GetGenresSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "genres": {
+                                "$ref": "#/components/schemas/Genres"
+                            }
+                        },
+                        "required": [
+                            "genres"
+                        ]
+                    }
+                ]
+            },
+            "GetGenresResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested genres element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetGenresSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetGenresResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getgenres/"
+                }
+            },
+            "Index": {
+                "type": "object",
+                "description": "An indexed artist list.",
+                "externalDocs": {
+                    "description": "Index",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/index_/"
+                },
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Index name"
+                    },
+                    "artist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Artist"
+                        },
+                        "description": "Artist list"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "Indexes": {
+                "type": "object",
+                "description": "Artist list.",
+                "externalDocs": {
+                    "description": "Indexes",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/indexes/"
+                },
+                "properties": {
+                    "ignoredArticles": {
+                        "type": "string",
+                        "description": "The ignored articles"
+                    },
+                    "lastModified": {
+                        "type": "integer",
+                        "description": "Last time the index was modified in milliseconds after January 1, 1970 UTC"
+                    },
+                    "shortcut": {
+                        "type": "array",
+                        "description": "Shortcut",
+                        "items": {
+                            "$ref": "#/components/schemas/Artist"
+                        }
+                    },
+                    "child": {
+                        "type": "array",
+                        "description": "Array of children",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        }
+                    },
+                    "index": {
+                        "type": "array",
+                        "description": "Indexed artists",
+                        "items": {
+                            "$ref": "#/components/schemas/Index"
+                        }
+                    }
+                },
+                "required": [
+                    "ignoredArticles",
+                    "lastModified"
+                ]
+            },
+            "GetIndexesSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "indexes": {
+                                "$ref": "#/components/schemas/Indexes"
+                            }
+                        },
+                        "required": [
+                            "indexes"
+                        ]
+                    }
+                ]
+            },
+            "GetIndexesResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested indexes element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetIndexesSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetIndexesResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getindexes/"
+                }
+            },
+            "InternetRadioStation": {
+                "type": "object",
+                "description": "An internetRadioStation.",
+                "externalDocs": {
+                    "description": "InternetRadioStation",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/internetradiostation/"
+                },
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The Id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The name"
+                    },
+                    "streamUrl": {
+                        "type": "string",
+                        "description": "The streamUrl"
+                    },
+                    "homePageUrl": {
+                        "type": "string",
+                        "description": "Genre name"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "streamUrl"
+                ]
+            },
+            "InternetRadioStations": {
+                "type": "object",
+                "description": "internetRadioStations.",
+                "externalDocs": {
+                    "description": "InternetRadioStations",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/internetradiostations/"
+                },
+                "properties": {
+                    "internetRadioStation": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/InternetRadioStation"
+                        },
+                        "description": "A list of internetRadioStation"
+                    }
+                }
+            },
+            "GetInternetRadioStationsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "internetRadioStations": {
+                                "$ref": "#/components/schemas/InternetRadioStations"
+                            }
+                        },
+                        "required": [
+                            "internetRadioStations"
+                        ]
+                    }
+                ]
+            },
+            "GetInternetRadioStationsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested internetRadioStations element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetInternetRadioStationsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetInternetRadioStationsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getinternetradiostations/"
+                }
+            },
+            "License": {
+                "type": "object",
+                "description": "getLicense result.",
+                "externalDocs": {
+                    "description": "License",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/license/"
+                },
+                "properties": {
+                    "valid": {
+                        "type": "boolean",
+                        "description": "The status of the license"
+                    },
+                    "email": {
+                        "type": "string",
+                        "description": "User email"
+                    },
+                    "licenseExpires": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "End of license date. [ISO 8601]"
+                    },
+                    "trialExpires": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "End of trial date. [ISO 8601]"
+                    }
+                },
+                "required": [
+                    "valid"
+                ]
+            },
+            "GetLicenseSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "license": {
+                                "$ref": "#/components/schemas/License"
+                            }
+                        },
+                        "required": [
+                            "license"
+                        ]
+                    }
+                ]
+            },
+            "GetLicenseResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested license element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetLicenseSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetLicenseResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlicense/"
+                }
+            },
+            "Lyrics": {
+                "type": "object",
+                "description": "Lyrics.",
+                "externalDocs": {
+                    "description": "Lyrics",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/lyrics/"
+                },
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The lyrics"
+                    },
+                    "artist": {
+                        "type": "string",
+                        "description": "The artist name"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "The song title"
+                    }
+                },
+                "required": [
+                    "lyrics"
+                ]
+            },
+            "GetLyricsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "lyrics": {
+                                "$ref": "#/components/schemas/Lyrics"
+                            }
+                        },
+                        "required": [
+                            "lyrics"
+                        ]
+                    }
+                ]
+            },
+            "GetLyricsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested lyrics element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetLyricsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetLicenseResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlyrics/"
+                }
+            },
+            "Line": {
+                "type": "object",
+                "description": "One line of a song lyric",
+                "externalDocs": {
+                    "description": "Line",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/line/"
+                },
+                "properties": {
+                    "value": {
+                        "type": "string",
+                        "description": "The actual text of this line"
+                    },
+                    "start": {
+                        "type": "number",
+                        "description": "The start time of the lyrics, relative to the start time of the track, in milliseconds. If this is not part of synced lyrics, start __must__ be omitted"
+                    }
+                },
+                "required": [
+                    "value"
+                ]
+            },
+            "StructuredLyrics": {
+                "type": "object",
+                "description": "Structured lyrics",
+                "externalDocs": {
+                    "description": "StructuredLyrics",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/structuredlyrics/"
+                },
+                "properties": {
+                    "lang": {
+                        "type": "string",
+                        "description": "The lyrics language (ideally ISO 639). If the language is unknown (e.g. lrc file), the server must return `und` (ISO standard) or `xxx` (common value for taggers). Ideally, the server will return lang as an ISO 639 (2/3) code. However, tagged files and external lyrics can come with any value as a potential language code, so clients should take care when displaying lang.\n\nFurthermore, there is special behavior for the value xxx. While not an ISO code, it is commonly used by taggers and other parsing software. Clients should treat xxx as not having a specified language (equivalent to the und code)."
+                    },
+                    "synced": {
+                        "type": "boolean",
+                        "description": "True if the lyrics are synced, false otherwise"
+                    },
+                    "line": {
+                        "type": "array",
+                        "description": "The actual lyrics. Ordered by start time (synced) or appearance order (unsynced)",
+                        "items": {
+                            "$ref": "#/components/schemas/Line"
+                        }
+                    },
+                    "displayArtist": {
+                        "type": "string",
+                        "description": "The artist name to display. This could be the localized name, or any other value"
+                    },
+                    "displayTitle": {
+                        "type": "string",
+                        "description": "The title to display. This could be the song title (localized), or any other value"
+                    },
+                    "offset": {
+                        "type": "number",
+                        "description": "The offset to apply to all lyrics, in milliseconds. Positive means lyrics appear sooner, negative means later. If not included, the offset must be assumed to be 0"
+                    }
+                },
+                "required": [
+                    "lang",
+                    "synced",
+                    "line"
+                ]
+            },
+            "LyricsList": {
+                "type": "object",
+                "description": "List of structured lyrics",
+                "externalDocs": {
+                    "description": "LyricsList",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/lyricslist/"
+                },
+                "properties": {
+                    "structuredLyrics": {
+                        "type": "array",
+                        "description": "Structured lyrics. There can be multiple lyrics of the same type with the same language",
+                        "items": {
+                            "$ref": "#/components/schemas/StructuredLyrics"
+                        }
+                    }
+                }
+            },
+            "GetLyricsBySongIdSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "lyricsList": {
+                                "$ref": "#/components/schemas/LyricsList"
+                            }
+                        },
+                        "required": [
+                            "lyricsList"
+                        ]
+                    }
+                ]
+            },
+            "GetLyricsBySongIdResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested lyricsList",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetLyricsBySongIdSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetLyricsBySongIdResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getlyricsbysongid/"
+                }
+            },
+            "Directory": {
+                "type": "object",
+                "description": "Directory.",
+                "externalDocs": {
+                    "description": "Directory",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/directory/"
+                },
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The id"
+                    },
+                    "parent": {
+                        "type": "string",
+                        "description": "Parent item"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The directory name"
+                    },
+                    "starred": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Starred date [ISO 8601]"
+                    },
+                    "userRating": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "The user rating [1-5]"
+                    },
+                    "averageRating": {
+                        "type": "number",
+                        "minimum": 1,
+                        "maximum": 5,
+                        "description": "The average rating [1-5]"
+                    },
+                    "playCount": {
+                        "type": "integer",
+                        "description": "The play count"
+                    },
+                    "child": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "The directory content"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "GetMusicDirectorySuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "directory": {
+                                "$ref": "#/components/schemas/Directory"
+                            }
+                        },
+                        "required": [
+                            "directory"
+                        ]
+                    }
+                ]
+            },
+            "GetMusicDirectoryResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested directory element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetMusicDirectorySuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetMusicDirectoryResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicdirectory/"
+                }
+            },
+            "MusicFolder": {
+                "type": "object",
+                "description": "MusicFolder.",
+                "externalDocs": {
+                    "description": "MusicFolder",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/musicfolder/"
+                },
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "description": "The id"
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The folder name"
+                    }
+                },
+                "required": [
+                    "id"
+                ]
+            },
+            "MusicFolders": {
+                "type": "object",
+                "description": "MusicFolders.",
+                "externalDocs": {
+                    "description": "MusicFolders",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/musicfolders/"
+                },
+                "properties": {
+                    "musicFolder": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/MusicFolder"
+                        },
+                        "description": "The folders"
+                    }
+                }
+            },
+            "GetMusicFoldersSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "musicFolders": {
+                                "$ref": "#/components/schemas/MusicFolders"
+                            }
+                        },
+                        "required": [
+                            "musicFolders"
+                        ]
+                    }
+                ]
+            },
+            "GetMusicFoldersResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested musicFolders element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetMusicFoldersSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetMusicFoldersResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getmusicfolders/"
+                }
+            },
+            "PodcastStatus": {
+                "type": "string",
+                "description": "An enumeration of possible podcast statuses",
+                "externalDocs": {
+                    "description": "PodcastStatus",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/podcaststatus/"
+                },
+                "enum": [
+                    "new",
+                    "downloading",
+                    "completed",
+                    "error",
+                    "deleted",
+                    "skipped"
+                ]
+            },
+            "PodcastEpisode": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Child"
+                    },
+                    {
+                        "type": "object",
+                        "description": "A podcast episode.",
+                        "externalDocs": {
+                            "description": "PodcastEpisode",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/podcastepisode/"
+                        },
+                        "properties": {
+                            "streamId": {
+                                "type": "string",
+                                "description": "ID used for streaming podcast"
+                            },
+                            "channelId": {
+                                "type": "string",
+                                "description": "TID of the podcast channel"
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Episode description"
+                            },
+                            "status": {
+                                "$ref": "#/components/schemas/PodcastStatus"
+                            },
+                            "publishDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Date the episode was published [ISO 8601]"
+                            }
+                        },
+                        "required": [
+                            "channelId",
+                            "status"
+                        ]
+                    }
+                ]
+            },
+            "NewestPodcasts": {
+                "type": "object",
+                "description": "NewestPodcasts.",
+                "externalDocs": {
+                    "description": "NewestPodcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/newestpodcasts/"
+                },
+                "properties": {
+                    "episode": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PodcastEpisode"
+                        }
+                    }
+                }
+            },
+            "GetNewestPodcastsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "newestPodcasts": {
+                                "$ref": "#/components/schemas/NewestPodcasts"
+                            }
+                        },
+                        "required": [
+                            "newestPodcasts"
+                        ]
+                    }
+                ]
+            },
+            "GetNewestPodcastsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `newestPodcasts` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetNewestPodcastsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetNewestPodcastsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getnewestpodcasts/"
+                }
+            },
+            "NowPlayingEntry": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Child"
+                    },
+                    {
+                        "type": "object",
+                        "description": "NowPlayingEntry.",
+                        "externalDocs": {
+                            "description": "NowPlayingEntry",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/nowplayingentry/"
+                        },
+                        "properties": {
+                            "username": {
+                                "type": "string",
+                                "description": "The username"
+                            },
+                            "minutesAgo": {
+                                "type": "string",
+                                "description": "Last update"
+                            },
+                            "playerId": {
+                                "type": "string",
+                                "description": "Player Id"
+                            },
+                            "playerName": {
+                                "type": "string",
+                                "description": "Player name"
+                            }
+                        },
+                        "required": [
+                            "username",
+                            "minutesAgo",
+                            "playerId"
+                        ]
+                    }
+                ]
+            },
+            "NowPlaying": {
+                "type": "object",
+                "description": "nowPlaying.",
+                "externalDocs": {
+                    "description": "NowPlaying",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/nowplaying/"
+                },
+                "properties": {
+                    "entry": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NowPlayingEntry"
+                        },
+                        "description": "The now playing entries"
+                    }
+                },
+                "required": [
+                    "entry"
+                ]
+            },
+            "GetNowPlayingSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "nowPlaying": {
+                                "$ref": "#/components/schemas/NowPlaying"
+                            }
+                        },
+                        "required": [
+                            "nowPlaying"
+                        ]
+                    }
+                ]
+            },
+            "GetNowPlayingResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `nowPlaying` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetNowPlayingSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetNowPlayingResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getnowplaying/"
+                }
+            },
+            "OpenSubsonicExtension": {
+                "type": "object",
+                "description": "A supported OpenSubsonic API extension.",
+                "externalDocs": {
+                    "description": "OpenSubsonicExtension",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/opensubsonicextension/"
+                },
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the extension."
+                    },
+                    "versions": {
+                        "type": "array",
+                        "description": "The list of supported versions of the this extension.",
+                        "items": {
+                            "type": "integer"
+                        }
+                    }
+                },
+                "required": [
+                    "name",
+                    "versions"
+                ]
+            },
+            "GetOpenSubsonicExtensionsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "openSubsonicExtensions": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/components/schemas/OpenSubsonicExtension"
+                                }
+                            }
+                        },
+                        "required": [
+                            "openSubsonicExtensions"
+                        ]
+                    }
+                ]
+            },
+            "GetOpenSubsonicExtensionsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `openSubsonicExtensions` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetOpenSubsonicExtensionsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetOpenSubsonicExtensionsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getopensubsonicextensions/"
+                }
+            },
+            "GetPlaylistSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "playlist": {
+                                "$ref": "#/components/schemas/PlaylistWithSongs"
+                            }
+                        },
+                        "required": [
+                            "playlist"
+                        ]
+                    }
+                ]
+            },
+            "GetPlaylistResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested playlist element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetPlaylistSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetPlaylistResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylist/"
+                }
+            },
+            "Playlists": {
+                "type": "object",
+                "description": "Playlists.",
+                "externalDocs": {
+                    "description": "Playlists",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/playlists/"
+                },
+                "properties": {
+                    "playlist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Playlist"
+                        },
+                        "description": "The playlists"
+                    }
+                }
+            },
+            "GetPlaylistsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "playlists": {
+                                "$ref": "#/components/schemas/Playlists"
+                            }
+                        },
+                        "required": [
+                            "playlists"
+                        ]
+                    }
+                ]
+            },
+            "GetPlaylistsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `playlists` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetPlaylistsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetPlaylistsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplaylists/"
+                }
+            },
+            "PlayQueue": {
+                "type": "object",
+                "description": "NowPlayingEntry.",
+                "externalDocs": {
+                    "description": "PlayQueue",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/playqueue/"
+                },
+                "properties": {
+                    "current": {
+                        "type": "string",
+                        "description": "ID of currently playing track"
+                    },
+                    "position": {
+                        "type": "integer",
+                        "description": "Position in milliseconds of currently playing track"
+                    },
+                    "username": {
+                        "type": "string",
+                        "description": "The user this queue belongs to"
+                    },
+                    "changed": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Date modified [ISO 8601]"
+                    },
+                    "changedBy": {
+                        "type": "string",
+                        "description": "Name of client app"
+                    },
+                    "entry": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "The list of songs in the queue"
+                    }
+                },
+                "required": [
+                    "username",
+                    "changed",
+                    "changedBy"
+                ]
+            },
+            "GetPlayQueueSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "playQueue": {
+                                "$ref": "#/components/schemas/PlayQueue"
+                            }
+                        },
+                        "required": [
+                            "playQueue"
+                        ]
+                    }
+                ]
+            },
+            "GetPlayQueueResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `playQueue` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetPlayQueueSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetPlayQueueResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getplayqueue/"
+                }
+            },
+            "GetPodcastEpisodeSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "podcastEpisode": {
+                                "$ref": "#/components/schemas/PodcastEpisode"
+                            }
+                        },
+                        "required": [
+                            "podcastEpisode"
+                        ]
+                    }
+                ]
+            },
+            "GetPodcastEpisodeResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `podcastEpisode` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetPodcastEpisodeSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetPodcastEpisodeResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcastepisode/"
+                }
+            },
+            "PodcastChannel": {
+                "type": "object",
+                "description": "A Podcast channel",
+                "externalDocs": {
+                    "description": "PodcastChannel",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/podcastchannel/"
+                },
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The channel ID"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Podcast channel URL"
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "The channel title"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The channel description"
+                    },
+                    "coverArt": {
+                        "type": "string",
+                        "description": "ID used for retrieving cover art"
+                    },
+                    "originalImageUrl": {
+                        "type": "string",
+                        "description": "URL for original image of podcast channel"
+                    },
+                    "status": {
+                        "$ref": "#/components/schemas/PodcastStatus"
+                    },
+                    "errorMessage": {
+                        "type": "string",
+                        "description": "An error message"
+                    },
+                    "episode": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PodcastEpisode"
+                        },
+                        "description": "Podcast episodes with this channel"
+                    }
+                },
+                "required": [
+                    "id",
+                    "url",
+                    "status"
+                ]
+            },
+            "Podcasts": {
+                "type": "object",
+                "description": "Podcasts.",
+                "externalDocs": {
+                    "description": "Podcasts",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/podcasts/"
+                },
+                "properties": {
+                    "channel": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PodcastChannel"
+                        },
+                        "description": "Podcast channel(s)"
+                    }
+                }
+            },
+            "GetPodcastsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "podcasts": {
+                                "$ref": "#/components/schemas/Podcasts"
+                            }
+                        },
+                        "required": [
+                            "podcasts"
+                        ]
+                    }
+                ]
+            },
+            "GetPodcastsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `podcasts` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetPodcastsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetPodcastsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getpodcasts/"
+                }
+            },
+            "Songs": {
+                "type": "object",
+                "description": "Songs list.",
+                "externalDocs": {
+                    "description": "Songs",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/songs/"
+                },
+                "properties": {
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "List of songs"
+                    }
+                }
+            },
+            "GetRandomSongsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "randomSongs": {
+                                "$ref": "#/components/schemas/Songs"
+                            }
+                        },
+                        "required": [
+                            "randomSongs"
+                        ]
+                    }
+                ]
+            },
+            "GetRandomSongsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `randomSongs` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetRandomSongsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetRandomSongsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getrandomsongs/"
+                }
+            },
+            "ScanStatus": {
+                "type": "object",
+                "description": "Scan status information.",
+                "externalDocs": {
+                    "description": "ScanStatus",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/scanstatus/"
+                },
+                "properties": {
+                    "scanning": {
+                        "type": "boolean",
+                        "description": "The status of the scan"
+                    },
+                    "count": {
+                        "type": "integer",
+                        "description": "Scanned item count"
+                    }
+                },
+                "required": [
+                    "scanning"
+                ]
+            },
+            "GetScanStatusSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "scanStatus": {
+                                "$ref": "#/components/schemas/ScanStatus"
+                            }
+                        },
+                        "required": [
+                            "scanStatus"
+                        ]
+                    }
+                ]
+            },
+            "GetScanStatusResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `scanStatus` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetScanStatusSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetScanStatusResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getscanstatus/"
+                }
+            },
+            "GetSharesSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "shares": {
+                                "$ref": "#/components/schemas/Shares"
+                            }
+                        },
+                        "required": [
+                            "shares"
+                        ]
+                    }
+                ]
+            },
+            "GetSharesResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `shares` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetSharesSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetSharesResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getshares/"
+                }
+            },
+            "SimilarSongs": {
+                "type": "object",
+                "description": "SimilarSongs list.",
+                "externalDocs": {
+                    "description": "SimilarSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/similarsongs/"
+                },
+                "properties": {
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "List of songs"
+                    }
+                }
+            },
+            "GetSimilarSongsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "similarSongs": {
+                                "$ref": "#/components/schemas/SimilarSongs"
+                            }
+                        },
+                        "required": [
+                            "similarSongs"
+                        ]
+                    }
+                ]
+            },
+            "GetSimilarSongsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `similarSongs` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetSimilarSongsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetSimilarSongsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs/"
+                }
+            },
+            "SimilarSongs2": {
+                "type": "object",
+                "description": "SimilarSongs2 list.",
+                "externalDocs": {
+                    "description": "SimilarSongs2",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/similarsongs2/"
+                },
+                "properties": {
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "List of songs"
+                    }
+                }
+            },
+            "GetSimilarSongs2SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "similarSongs2": {
+                                "$ref": "#/components/schemas/SimilarSongs2"
+                            }
+                        },
+                        "required": [
+                            "similarSongs2"
+                        ]
+                    }
+                ]
+            },
+            "GetSimilarSongs2Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `similarSongs2` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetSimilarSongs2SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetSimilarSongs2Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsimilarsongs2/"
+                }
+            },
+            "GetSongSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "song": {
+                                "$ref": "#/components/schemas/Child"
+                            }
+                        },
+                        "required": [
+                            "song"
+                        ]
+                    }
+                ]
+            },
+            "GetSongResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `song` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetSongSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetSongResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsong/"
+                }
+            },
+            "GetSongsByGenreSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "songsByGenre": {
+                                "$ref": "#/components/schemas/Songs"
+                            }
+                        },
+                        "required": [
+                            "songsByGenre"
+                        ]
+                    }
+                ]
+            },
+            "GetSongsByGenreResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `songsByGenre` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetSongsByGenreSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetSongsByGenreResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getsongsbygenre/"
+                }
+            },
+            "Starred": {
+                "type": "object",
+                "description": "starred.",
+                "externalDocs": {
+                    "description": "Starred",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/starred/"
+                },
+                "properties": {
+                    "artist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Artist"
+                        },
+                        "description": "Starred artists"
+                    },
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Starred albums"
+                    },
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Starred songs"
+                    }
+                }
+            },
+            "GetStarredSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "starred": {
+                                "$ref": "#/components/schemas/Starred"
+                            }
+                        },
+                        "required": [
+                            "starred"
+                        ]
+                    }
+                ]
+            },
+            "GetStarredResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `starred` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetStarredSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetStarredResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred/"
+                }
+            },
+            "Starred2": {
+                "type": "object",
+                "description": "Starred2.",
+                "externalDocs": {
+                    "description": "Starred2",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/starred2/"
+                },
+                "properties": {
+                    "artist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        },
+                        "description": "Starred artists"
+                    },
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AlbumID3"
+                        },
+                        "description": "Starred albums"
+                    },
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Starred songs"
+                    }
+                }
+            },
+            "GetStarred2SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "starred2": {
+                                "$ref": "#/components/schemas/Starred2"
+                            }
+                        },
+                        "required": [
+                            "starred2"
+                        ]
+                    }
+                ]
+            },
+            "GetStarred2Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `starred2` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetStarred2SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetStarred2Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getstarred2/"
+                }
+            },
+            "TopSongs": {
+                "type": "object",
+                "description": "TopSongs list.",
+                "externalDocs": {
+                    "description": "TopSongs",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/topsongs/"
+                },
+                "properties": {
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "List of songs"
+                    }
+                }
+            },
+            "GetTopSongsSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "topSongs": {
+                                "$ref": "#/components/schemas/TopSongs"
+                            }
+                        },
+                        "required": [
+                            "topSongs"
+                        ]
+                    }
+                ]
+            },
+            "GetTopSongsResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `topSongs` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetTopSongsSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetTopSongsResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/gettopsongs/"
+                }
+            },
+            "User": {
+                "type": "object",
+                "description": "user.",
+                "externalDocs": {
+                    "description": "User",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/user/"
+                },
+                "properties": {
+                    "username": {
+                        "type": "string",
+                        "description": "Username"
+                    },
+                    "scrobblingEnabled": {
+                        "type": "boolean",
+                        "description": "Scrobbling enabled"
+                    },
+                    "maxBitRate": {
+                        "type": "integer"
+                    },
+                    "adminRole": {
+                        "type": "boolean",
+                        "description": "Whether the user is an admin"
+                    },
+                    "settingsRole": {
+                        "type": "boolean",
+                        "description": "Whether the user is can edit settings"
+                    },
+                    "downloadRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can download"
+                    },
+                    "uploadRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can upload"
+                    },
+                    "playlistRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can create playlists"
+                    },
+                    "coverArtRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can get cover art"
+                    },
+                    "commentRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can create comments"
+                    },
+                    "podcastRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can create/refresh podcasts"
+                    },
+                    "streamRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can stream"
+                    },
+                    "jukeboxRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can control the jukebox"
+                    },
+                    "shareRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can create a stream"
+                    },
+                    "videoConversionRole": {
+                        "type": "boolean",
+                        "description": "Whether the user can convert videos"
+                    },
+                    "avatarLastChanged": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Last time the avatar was changed [ISO 8601]"
+                    },
+                    "folder": {
+                        "type": "array",
+                        "items": {
+                            "type": "integer"
+                        },
+                        "description": "Folder ID(s)"
+                    }
+                },
+                "required": [
+                    "username",
+                    "scrobblingEnabled",
+                    "adminRole",
+                    "settingsRole",
+                    "downloadRole",
+                    "uploadRole",
+                    "playlistRole",
+                    "coverArtRole",
+                    "commentRole",
+                    "podcastRole",
+                    "streamRole",
+                    "jukeboxRole",
+                    "shareRole",
+                    "videoConversionRole"
+                ]
+            },
+            "GetUserSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "user": {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        },
+                        "required": [
+                            "user"
+                        ]
+                    }
+                ]
+            },
+            "GetUserResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `user` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetUserSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetUserResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getuser/"
+                }
+            },
+            "Users": {
+                "type": "object",
+                "description": "users.",
+                "externalDocs": {
+                    "description": "Users",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/users/"
+                },
+                "properties": {
+                    "user": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/User"
+                        },
+                        "description": "Array of users"
+                    }
+                }
+            },
+            "GetUsersSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "users": {
+                                "$ref": "#/components/schemas/Users"
+                            }
+                        },
+                        "required": [
+                            "users"
+                        ]
+                    }
+                ]
+            },
+            "GetUsersResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `user` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetUsersSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetUsersResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getusers/"
+                }
+            },
+            "VideoInfo": {
+                "type": "object",
+                "description": "videoInfo. TODO",
+                "externalDocs": {
+                    "description": "VideoInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/videoinfo/"
+                }
+            },
+            "GetVideoInfoSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "videoInfo": {
+                                "$ref": "#/components/schemas/VideoInfo"
+                            }
+                        },
+                        "required": [
+                            "videoInfo"
+                        ]
+                    }
+                ]
+            },
+            "GetVideoInfoResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `videoInfo` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetVideoInfoSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetVideoInfoResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideoinfo/"
+                }
+            },
+            "Videos": {
+                "type": "object",
+                "description": "videos. TODO",
+                "externalDocs": {
+                    "description": "Videos",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/videos/"
+                }
+            },
+            "GetVideosSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "videos": {
+                                "$ref": "#/components/schemas/Videos"
+                            }
+                        },
+                        "required": [
+                            "videos"
+                        ]
+                    }
+                ]
+            },
+            "GetVideosResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `videos` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetVideosSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetVideosResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/getvideos/"
+                }
+            },
+            "JukeboxAction": {
+                "type": "string",
+                "description": "JukeBox action.",
+                "enum": [
+                    "get",
+                    "status",
+                    "set",
+                    "start",
+                    "stop",
+                    "skip",
+                    "add",
+                    "clear",
+                    "remove",
+                    "shuffle",
+                    "setGain"
+                ]
+            },
+            "JukeboxStatus": {
+                "type": "object",
+                "description": "jukeboxStatus.",
+                "externalDocs": {
+                    "description": "JukeboxStatus",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/jukeboxstatus/"
+                },
+                "properties": {
+                    "currentIndex": {
+                        "type": "integer",
+                        "description": "The current index of the song being played"
+                    },
+                    "playing": {
+                        "type": "boolean",
+                        "description": "Whether the queue is currently playing"
+                    },
+                    "volume": {
+                        "type": "integer",
+                        "description": "Volume, in a range of [0.0, 1.0]",
+                        "format": "float",
+                        "minimum": 0.0,
+                        "maximum": 1.0
+                    },
+                    "position": {
+                        "type": "integer",
+                        "description": "The current position of the track in seconds"
+                    }
+                },
+                "required": [
+                    "currentIndex",
+                    "playing",
+                    "volume"
+                ]
+            },
+            "JukeboxPlaylist": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/JukeboxStatus"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "entry": {
+                                "type": "array",
+                                "description": "The songs currently enqueued in the jukebox",
+                                "items": {
+                                    "$ref": "#/components/schemas/Child"
+                                }
+                            }
+                        },
+                        "externalDocs": {
+                            "description": "JukeboxPlaylist",
+                            "url": "https://opensubsonic.netlify.app/docs/responses/jukeboxplaylist/"
+                        }
+                    }
+                ]
+            },
+            "JukeboxControlSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "jukeboxStatus": {
+                                "$ref": "#/components/schemas/JukeboxStatus"
+                            },
+                            "jukeboxPlaylist": {
+                                "$ref": "#/components/schemas/JukeboxPlaylist"
+                            }
+                        }
+                    }
+                ]
+            },
+            "JukeboxControlResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested :\n\n- jukeboxStatus for all actions but get\n- jukeboxPlaylist for get action",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/JukeboxControlSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "JukeboxControlSuccessResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/jukeboxcontrol/"
+                }
+            },
+            "SearchResult": {
+                "type": "object",
+                "description": "searchResult. TODO",
+                "externalDocs": {
+                    "description": "SearchResult",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/searchresult/"
+                }
+            },
+            "SearchSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "searchResult": {
+                                "$ref": "#/components/schemas/SearchResult"
+                            }
+                        },
+                        "required": [
+                            "searchResult"
+                        ]
+                    }
+                ]
+            },
+            "SearchResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `searchResult` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/SearchSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "SearchResultResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search/"
+                }
+            },
+            "SearchResult2": {
+                "type": "object",
+                "description": "searchResult2",
+                "externalDocs": {
+                    "description": "SearchResult2",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/searchresult2/"
+                },
+                "properties": {
+                    "artist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Artist"
+                        },
+                        "description": "Starred artists"
+                    },
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Starred albums"
+                    },
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Starred songs"
+                    }
+                }
+            },
+            "Search2SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "searchResult2": {
+                                "$ref": "#/components/schemas/SearchResult2"
+                            }
+                        },
+                        "required": [
+                            "searchResult2"
+                        ]
+                    }
+                ]
+            },
+            "Search2Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `searchResult2` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Search2SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "SearchResult2Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search2/"
+                }
+            },
+            "SearchResult3": {
+                "type": "object",
+                "description": "searchResult3",
+                "externalDocs": {
+                    "description": "SearchResult3",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/searchresult3/"
+                },
+                "properties": {
+                    "artist": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ArtistID3"
+                        },
+                        "description": "Matching artists"
+                    },
+                    "album": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AlbumID3"
+                        },
+                        "description": "Matching albums"
+                    },
+                    "song": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Child"
+                        },
+                        "description": "Matching songs"
+                    }
+                }
+            },
+            "Search3SuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "searchResult3": {
+                                "$ref": "#/components/schemas/SearchResult3"
+                            }
+                        },
+                        "required": [
+                            "searchResult3"
+                        ]
+                    }
+                ]
+            },
+            "Search3Response": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `searchResult3` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/Search3SuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "SearchResult3Response",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/search3/"
+                }
+            },
+            "StartScanSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "scanStatus": {
+                                "$ref": "#/components/schemas/ScanStatus"
+                            }
+                        },
+                        "required": [
+                            "scanStatus"
+                        ]
+                    }
+                ]
+            },
+            "StartScanResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested `scanStatus` element on success.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/StartScanSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "StartScanResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/startscan/"
+                }
+            },
+            "TokenInfo": {
+                "type": "object",
+                "description": "Information about an API key",
+                "externalDocs": {
+                    "description": "TokenInfo",
+                    "url": "https://opensubsonic.netlify.app/docs/responses/tokeninfo/"
+                },
+                "properties": {
+                    "username": {
+                        "type": "string",
+                        "description": "Username associated with token"
+                    }
+                },
+                "required": [
+                    "username"
+                ]
+            },
+            "GetTokenInfoSuccessResponse": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/SubsonicSuccessResponse"
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "tokenInfo": {
+                                "$ref": "#/components/schemas/TokenInfo"
+                            }
+                        },
+                        "required": [
+                            "tokenInfo"
+                        ]
+                    }
+                ]
+            },
+            "GetTokenInfoResponse": {
+                "type": "object",
+                "description": "A subsonic-response element with a nested tokenInfo on success, or error 44 on invalid token.",
+                "properties": {
+                    "subsonic-response": {
+                        "oneOf": [
+                            {
+                                "$ref": "#/components/schemas/GetTokenInfoSuccessResponse"
+                            },
+                            {
+                                "$ref": "#/components/schemas/SubsonicFailureResponse"
+                            }
+                        ]
+                    }
+                },
+                "externalDocs": {
+                    "description": "GetTokenInfoResponse",
+                    "url": "https://opensubsonic.netlify.app/docs/endpoints/gettokeninfo/"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR attempts to add an `openapi.json` to the project for client library/documentation generation. This is a big one.

**The file should be usable but I will try generating a Python client library soon to see how well it works, but work on the PR can be started even now**. Ideally all extension should be added the schema. So far I added extension endpoints, parameters, responses, http post endpoints.

It's Github, there is a live URL to the json file, so technically it can be used for stuff straight away...

Everything below will need to be resolved one way or another, they need decisions by the maintainers of the API specification.. 

## Required work to be done before merge

- [ ] Split out all endpoints, responses and component schemas out to files matching the folder structure using relative path refs. All files should resolve properly in editors for ease of editing.
- [ ] Add build command that resolves all relative refs (and only those) properly handling nested refs
    * If top level ref: dumps contents into final `openapi.json`
    * If nested ref: convert into `#/...` format (final place in the `openapi.json` should be inferred from the file path alone, e.g. `/content/en/docs/Responses/ArtistID3.json` goes to `#/components/schemas/ArtistID3`)
- [ ] Add step to validate final `openapi.json` during build and for PRs

## Work checklist(s)

### Decide to Approve/Change/Fix every difference between `openapi.json` and OpenSubsonic API spec

- [ ] Some typo fixes I failed to document :( I will need to find them again and add them to the section below
- [ ] Added `minimum: 0` to integer types where it's implied (`count`, `offset`, unix timestamp, `position`)
- [ ] forces `json` format on every endpoint. `xml` response formats should not be a big hassle but client library generation will probably become problematic.
- [ ] All extensions are added to the schema and tagged as "Extension", and have a 404 return type as well that described as "Not Implemented"
- [ ] Excluded `example`s, opted to use `externalDocs` only because it made the Swagger and Redoc generated documents harder to read. I might add them if they make sense for generated client code.
- [ ] Query Parameters only existing via Extensions are always added and marked in their `description field`
- [ ] `HTTP form POST` extension support might be stricter than what's allowed (global params - auth and format params -  only allowed as query params, endpoint specific params are the only ones allowed in request body)

### Decide to Schedule/Postpone/Fix/Resolve all issues/inconsistencies found in spec

They might need to be resolved before/along with this PR or they can be resolved at a later time. It would be nice if all of them could be answered.

- [ ] `ItemDate` description and spec doesn't match (in required fields)
- [ ] Disc number must be a number but obviously it can be other things
- [ ] `getAlbumInfo2` return type incorrect (based on `AlbumList`)?
- [ ] `downloadPodcastEpisode` return type incorrect?
- [ ] `deleteBookmark` summary and description is wrong
- [ ] `download` error payload schema missing completely
- [ ] `getArtists` page first `artists` link is broken
- [ ] `getAvatar` `username` parameter is "required" and has a "default" as well. it should be one or the other
- [ ] `getCaptions` return payload not clear
- [ ] `getCoverArt` `size` param type not specified, I assume `int` as pixels
- [ ] `Indexes` `ignoredArticles` pattern is unclear, it was comma-separated list as string before
- [ ] `internetRadioStation` `homePageUrl` has wrong details
- [ ] `getLyrics` `artist` and `title` query parameters are really optional?
- [ ] is `getLyrics` returns only one element?
- [ ] Extension not supported error is unclear, assumed servers will 404 on the request.
- [ ] `PodcastEpisode` description "PodcastEntry extends Child". Wrong name used?
- [ ] `NowPlayingEntry` `minutesAgo` format is unclear
- [ ] `PlayQueue` description incorrect
- [ ] `PodcastChannel` `errorMessage` existence could depend on `status` in documentation?
- [ ] `GetSimilarSongs` and `GetSimilarSongs2` response type is the same in the spec (not the names)?
- [ ] `User` example uses booleans and integers as strings, but they are typed as booleans and integers.
- [ ] `VideoInfo` is not documented
- [ ] `Videos` is not documented
- [ ] `hls` endpoint summary matches `download`
- [ ] Typo in `search` `album` parameters's comment
- [ ] `search` `any` parameter type unclear
- [ ] `SearchResult` is not documented
- [ ] `SearchResult2` all field details are incorrect
- [ ] `stream` `timeOffset` param's description typo, "Transcode Offet"
- [ ] [tokenInfo](https://opensubsonic.netlify.app/docs/responses/tokeninfo/) data is too deeply nested in docs?
- [ ] [tokenInfo](https://opensubsonic.netlify.app/docs/endpoints/tokeninfo/) says "A subsonic-response element with a nested tokenInfo on success, or error 44 on invalid token.". Does that mean it cannot return any other error code on error?
- [ ] `unstar` summary is incorrect
- [ ] `updateuser` is missing `playlistRole` parameter?
- [ ] `createuser` is missing `maxBitRate` parameter?

### Schedule/Require/Postpone/Request future improvements for `openapi.json`

- [ ] Could use inheritance for ArtistInfo and ArtistInfo2
- [ ] `getPodcasts` payload dependent on query param `includeEpisodes`, but it doesn't indicate that structurally.
- [ ] `jukeboxControl` payload dependent on query param `action: get`, but it doesn't indicate that structurally.
- [ ] `getAlbumList` and `getAlbumList2` POST params can be a tagged union
- [ ] `jukeboxcontrol` POST params can be a tagged union
- [ ] Add version info for each endpoint and add 404 responses where the endpoint didn't exist since v1
- [ ] add (back) examples

### Review generated OpenAPI documentation to verify they are OK

- [ ] SwaggerUI
- [ ] ReDoc

### Verify this OpenAPI schema against servers

Using at least one of the tools from [here](https://openapi.tools/#data-validators) the `openapi.json` should be tested against all endpoints request/response payloads on the servers below. Any mismatches/errors should be fixed if `openapi.json` doesn't follow the spec. Ideally will be no behaviors implemented in servers that are different in the official API spec.

* Navidrome
* gonic
* lms
* ampache
* and all others listed in https://opensubsonic.netlify.app/docs/?

### Client libraries generated from this `openapi.json` are generated OK

#### Python

- [ ] synchronous library
- [ ] async library
- [ ] library using `pydantic` for response payload validation

Proposed client generation libraries for testing

* https://github.com/openapi-generators/openapi-python-client
* https://openapi-generator.tech/docs/generators/python/

#### Typescript

- [ ] Working async library
- [ ] Working library using `zod` for response payload validation

Proposed client generation libraries for testing

* https://www.npmjs.com/package/openapi-typescript
* https://www.npmjs.com/package/@openapitools/openapi-generator-cli (not really good but official)
* https://www.npmjs.com/package/openapi-zod-client

#### Kotlin

- [ ] Working library
- [ ] Use library against Navidrome and test every endpoint
- [ ] Use library against any server requested by maintainers and test every endpoint

Proposed client generation libraries for testing

* https://github.com/Aallam/openai-kotlin
* https://openapi-generator.tech/docs/generators/kotlin/

#### Any other language required by maintainers

* Dart?
* C#?

## Major Future Work
* Documentation could be generated from the `openapi.json` (in its current form)
* OpenAPI specific documentation could be generated along with the API spec