### PR TITLE
Remove duplicated fields in Child object

### DIFF
--- a/content/en/docs/Responses/Child.md
+++ b/content/en/docs/Responses/Child.md
@@ -202,8 +202,6 @@ description: >
 | `displayComposer` | `string` | No |  **Yes**   | The single value display composer. |
 | `moods` | Array of `string` | No | **Yes**  | The list of all moods of the song. |
 | `replayGain` | [`ReplayGain`](../replaygain) | No | **Yes**  | The replaygain data of the song. |
-| `moods` | Array of `string` | No | **Yes**    | The list of all moods of the song. |
-| `replayGain` | [`ReplayGain`](../replaygain) | No | **Yes**    | The replaygain data of the song. |
 | `explicitStatus` | `string` | No |  **Yes**    | Returns "explicit", "clean" or "". (For songs extracted from tags "ITUNESADVISORY": 1 = explicit, 2 = clean, MP4 "rtng": 1 or 4 = explicit, 2 = clean. See [`albumID3`](../albumid3) for albums) |
 
 


### PR DESCRIPTION
The replayGain and moods fields were duplicated in the table describing the data members, remove the extra entries.