### PR TITLE
Fix data type of two NowPlayingEntry fields

### DIFF
--- a/content/en/docs/Responses/NowPlayingEntry.md
+++ b/content/en/docs/Responses/NowPlayingEntry.md
@@ -80,6 +80,6 @@ description: >
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
 | `username` | `string` | **Yes** |     | The username |
-| `minutesAgo` | `string` | **Yes** |     | Last update |
-| `playerId` | `boolean` | **Yes** |     | Player Id |
+| `minutesAgo` | `integer` | **Yes** |     | Last update |
+| `playerId` | `integer` | **Yes** |     | Player Id |
 | `playerName` | `string` | No |     | Player name |


### PR DESCRIPTION
The minutesAgo and playerId fields were marked as string and boolean respectively. In the example they are both integers.