### PR TITLE
linting, links to responses and endpoints reference their title

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,16 @@
+{
+  "default": true,
+  "MD001": true,
+  "MD003": { "style": "atx" },
+  "MD004": { "style": "consistent" },
+  "MD007": { "indent": 2 },
+  "MD012": true,
+  "MD013": false,
+  "MD022": true,
+  "MD029": { "style": "ordered" },
+  "MD033": false,
+  "MD034": false,
+  "MD040": true,
+  "MD041": false,
+  "MD059": false
+}

--- a/content/en/docs/Endpoints/addchatmessage.md
+++ b/content/en/docs/Endpoints/addchatmessage.md
@@ -4,7 +4,7 @@ linkTitle: "addChatMessage"
 categories:
 - Chat
 description: >
-    Adds a message to the chat log.
+  Adds a message to the chat log.
 ---
 
 `http://your-server/rest/addChatMessage` Since [1.2.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/changepassword.md
+++ b/content/en/docs/Endpoints/changepassword.md
@@ -4,7 +4,7 @@ linkTitle: "changePassword"
 categories:
 - User management
 description: >
-    Changes the password of an existing user on the server.
+  Changes the password of an existing user on the server.
 ---
 
 `http://your-server/rest/changePassword` Since [1.1.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/createbookmark.md
+++ b/content/en/docs/Endpoints/createbookmark.md
@@ -4,7 +4,7 @@ linkTitle: "createBookmark"
 categories:
 - Bookmarks
 description: >
-    Creates or updates a bookmark.
+  Creates or updates a bookmark.
 ---
 
 `http://your-server/rest/createBookmark` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/createinternetradiostation.md
+++ b/content/en/docs/Endpoints/createinternetradiostation.md
@@ -4,7 +4,7 @@ linkTitle: "createInternetRadioStation"
 categories:
 - Internet radio
 description: >
-    Adds a new internet radio station.
+  Adds a new internet radio station.
 ---
 
 `http://your-server/rest/createInternetRadioStation` Since [1.16.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/createpodcastchannel.md
+++ b/content/en/docs/Endpoints/createpodcastchannel.md
@@ -4,7 +4,7 @@ linkTitle: "createPodcastChannel"
 categories:
 - Podcast
 description: >
-    Adds a new Podcast channel.
+  Adds a new Podcast channel.
 ---
 
 `http://your-server/rest/createPodcastChannel` Since [1.9.0](.././subsonic-versions)

--- a/content/en/docs/Endpoints/createshare.md
+++ b/content/en/docs/Endpoints/createshare.md
@@ -4,7 +4,7 @@ linkTitle: "createShare"
 categories:
 - Sharing
 description: >
-    Creates a public URL that can be used by anyone to stream music or video from the server.
+  Creates a public URL that can be used by anyone to stream music or video from the server.
 ---
 
 `http://your-server/rest/createShare` Since [1.6.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/createuser.md
+++ b/content/en/docs/Endpoints/createuser.md
@@ -4,7 +4,7 @@ linkTitle: "createUser"
 categories:
 - User management
 description: >
-    Creates a new user on the server.
+  Creates a new user on the server.
 ---
 
 `http://your-server/rest/createUser` Since [1.1.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deletebookmark.md
+++ b/content/en/docs/Endpoints/deletebookmark.md
@@ -4,7 +4,7 @@ linkTitle: "deleteBookmark"
 categories:
 - Bookmarks
 description: >
-    Creates or updates a bookmark.
+  Creates or updates a bookmark.
 ---
 
 `http://your-server/rest/deleteBookmark` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deleteinternetradiostation.md
+++ b/content/en/docs/Endpoints/deleteinternetradiostation.md
@@ -4,7 +4,7 @@ linkTitle: "deleteInternetRadioStation"
 categories:
 - Internet radio
 description: >
-    Deletes an existing internet radio station.
+  Deletes an existing internet radio station.
 ---
 
 `http://your-server/rest/deleteInternetRadioStation` Since [1.16.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deleteplaylist.md
+++ b/content/en/docs/Endpoints/deleteplaylist.md
@@ -4,7 +4,7 @@ linkTitle: "deletePlaylist"
 categories:
 - Playlists
 description: >
-    Deletes a saved playlist.
+  Deletes a saved playlist.
 ---
 
 `http://your-server/rest/deletePlaylist` Since [1.2.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deletepodcastchannel.md
+++ b/content/en/docs/Endpoints/deletepodcastchannel.md
@@ -4,7 +4,7 @@ linkTitle: "deletePodcastChannel"
 categories:
 - Podcast
 description: >
-    Deletes a Podcast channel.
+  Deletes a Podcast channel.
 ---
 
 `http://your-server/rest/deletePodcastChannel` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deletepodcastepisode.md
+++ b/content/en/docs/Endpoints/deletepodcastepisode.md
@@ -4,7 +4,7 @@ linkTitle: "deletePodcastEpisode"
 categories:
 - Podcast
 description: >
-    Deletes a Podcast episode.
+  Deletes a Podcast episode.
 ---
 
 `http://your-server/rest/deletePodcastEpisode` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deleteshare.md
+++ b/content/en/docs/Endpoints/deleteshare.md
@@ -4,7 +4,7 @@ linkTitle: "deleteShare"
 categories:
 - Sharing
 description: >
-    Deletes an existing share.
+  Deletes an existing share.
 ---
 
 `http://your-server/rest/deleteShare` Since [1.6.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/deleteuser.md
+++ b/content/en/docs/Endpoints/deleteuser.md
@@ -4,7 +4,7 @@ linkTitle: "deleteUser"
 categories:
 - User management
 description: >
-    Deletes an existing user on the server.
+  Deletes an existing user on the server.
 ---
 
 `http://your-server/rest/deleteUser` Since [1.3.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/download.md
+++ b/content/en/docs/Endpoints/download.md
@@ -4,7 +4,7 @@ linkTitle: "download"
 categories:
 - Media retrieval
 description: >
-    Downloads a given media file.
+  Downloads a given media file.
 ---
 
 `http://your-server/rest/download` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/downloadpodcastepisode.md
+++ b/content/en/docs/Endpoints/downloadpodcastepisode.md
@@ -4,7 +4,7 @@ linkTitle: "downloadPodcastEpisode"
 categories:
 - Podcast
 description: >
-    Request the server to start downloading a given Podcast episode. 
+  Request the server to start downloading a given Podcast episode.
 ---
 
 `http://your-server/rest/downloadPodcastEpisode` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -6,7 +6,7 @@ OpenSubsonic:
 categories:
   - Media retrieval
 description: >
-  Add support for synchronized lyrics, multiple languages, and retrieval by song ID
+  Add support for synchronized lyrics, multiple languages, and retrieval by song ID.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)
@@ -22,7 +22,7 @@ The lyrics can come from embedded tags (`SYLT`/`USLT`), LRC file/text file, or a
 
 | Parameter | Req.    | OpenS.  | Default | Comment       |
 | --------- | ------- | ------- | ------- | ------------- |
-| `id`      | **Yes** | **Yes** |         | The track ID. |                                                                                         
+| `id`      | **Yes** | **Yes** |         | The track ID. |
 
 {{< alert color="warning" title="Special notes about the lang field" >}}
 Ideally, the server will return `lang` as an ISO 639 (2/3) code.

--- a/content/en/docs/Endpoints/getalbum.md
+++ b/content/en/docs/Endpoints/getalbum.md
@@ -23,7 +23,7 @@ Returns details for an album, including a list of songs. This method organizes m
 
 ### Result
 
-A [`subsonic-response`](../../responses/subsonic-response) element with a nested [`album`](../../responses/albumid3withsongs) element on success.
+A [`subsonic-response`](../../responses/subsonic-response) element with a nested [`AlbumID3WithSongs`](../../responses/albumid3withsongs) element on success.
 
 {{< tabpane persist=false >}}
 {{< tab header="**Example**:" disabled=true />}}
@@ -192,4 +192,4 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
-| `album` | [`album`](../../responses/albumid3withsongs) | **Yes** |   | The album |
+| `album` | [`AlbumID3WithSongs`](../../responses/albumid3withsongs) | **Yes** |   | The album |

--- a/content/en/docs/Endpoints/getalbuminfo.md
+++ b/content/en/docs/Endpoints/getalbuminfo.md
@@ -4,7 +4,7 @@ linkTitle: "getAlbumInfo"
 categories:
 - Browsing
 description: >
-    Returns album info.
+  Returns album info.
 ---
 
 `http://your-server/rest/getAlbumInfo` Since [1.14.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getalbuminfo2.md
+++ b/content/en/docs/Endpoints/getalbuminfo2.md
@@ -4,7 +4,7 @@ linkTitle: "getAlbumInfo2"
 categories:
 - Browsing
 description: >
-    Returns album info.
+  Returns album info.
 ---
 
 `http://your-server/rest/getAlbumInfo2` Since [1.14.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getartist.md
+++ b/content/en/docs/Endpoints/getartist.md
@@ -4,7 +4,7 @@ linkTitle: "getArtist"
 categories:
 - Browsing
 description: >
-    Returns details for an artist.
+  Returns details for an artist.
 ---
 
 `http://your-server/rest/getArtist` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getartistinfo.md
+++ b/content/en/docs/Endpoints/getartistinfo.md
@@ -4,7 +4,7 @@ linkTitle: "getArtistInfo"
 categories:
 - Browsing
 description: >
-    Returns artist info.
+  Returns artist info.
 ---
 
 `http://your-server/rest/getArtistInfo` Since [1.11.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getartistinfo2.md
+++ b/content/en/docs/Endpoints/getartistinfo2.md
@@ -4,7 +4,7 @@ linkTitle: "getArtistInfo2"
 categories:
 - Browsing
 description: >
-    Returns artist info.
+  Returns artist info.
 ---
 
 `http://your-server/rest/getArtistInfo2` Since [1.11.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getavatar.md
+++ b/content/en/docs/Endpoints/getavatar.md
@@ -4,7 +4,7 @@ linkTitle: "getAvatar"
 categories:
 - Media retrieval
 description: >
-    Returns the avatar (personal image) for a user.
+  Returns the avatar (personal image) for a user.
 ---
 
 `http://your-server/rest/getAvatar` Since [1.8.0](../../subsonic-versions)
@@ -13,9 +13,9 @@ Returns the avatar (personal image) for a user.
 
 ### Parameters
 
-| Parameter | Req. | OpenS. | Default | Comment |
-| --- | --- | --- | --- | --- |
-| `username` | **Yes** |     | The user in question.. |
+| Parameter  | Req.    | OpenS. | Default | Comment |
+| ---------- | ------- | ------ | ------- | ------- |
+| `username` | **Yes** |        | The user in question.. | |
 
 ### Example
 

--- a/content/en/docs/Endpoints/getbookmarks.md
+++ b/content/en/docs/Endpoints/getbookmarks.md
@@ -4,7 +4,7 @@ linkTitle: "getBookmarks"
 categories:
 - Bookmarks
 description: >
-    Returns all bookmarks for this user.
+  Returns all bookmarks for this user.
 ---
 
 `http://your-server/rest/getBookmarks` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getcaptions.md
+++ b/content/en/docs/Endpoints/getcaptions.md
@@ -4,7 +4,7 @@ linkTitle: "getCaptions"
 categories:
 - Media retrieval
 description: >
-    Returns captions (subtitles) for a video.
+  Returns captions (subtitles) for a video.
 ---
 
 `http://your-server/rest/getCaptions` Since [1.14.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getcoverart.md
+++ b/content/en/docs/Endpoints/getcoverart.md
@@ -4,7 +4,7 @@ linkTitle: "getCoverArt"
 categories:
 - Media retrieval
 description: >
-    Returns a cover art image.
+  Returns a cover art image.
 ---
 
 `http://your-server/rest/getCoverArt` Since [1.0.0](../../subsonic-versions)
@@ -13,10 +13,10 @@ Returns a cover art image.
 
 ### Parameters
 
-| Parameter | Req. | OpenS. | Default | Comment |
-| --- | --- | --- | --- | --- |
-| `id` | **Yes** |     | The coverArt ID. Returned by most entities likes [`Child`](../../responses/child) or [`AlbumID3`](../../responses/albumid3) |
-| `size` | No  |     | If specified, scale image to this size. |
+| Parameter | Req.    | OpenS. | Default | Comment |
+| --------- | ------- | ------ | ------- | --- |
+| `id`      | **Yes** |        | The coverArt ID. Returned by most entities likes [`Child`](../../responses/child) or [`AlbumID3`](../../responses/albumid3) | |
+| `size`    | No      |        | If specified, scale image to this size. | |
 
 ### Example
 

--- a/content/en/docs/Endpoints/getlicense.md
+++ b/content/en/docs/Endpoints/getlicense.md
@@ -4,7 +4,7 @@ linkTitle: "getLicense"
 categories:
 - System
 description: >
-    Get details about the software license. 
+  Get details about the software license.
 ---
 
 `http://your-server/rest/getLicense` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getlyrics.md
+++ b/content/en/docs/Endpoints/getlyrics.md
@@ -4,7 +4,7 @@ linkTitle: "getLyrics"
 categories:
 - Media retrieval
 description: >
-    Searches for and returns lyrics for a given song.
+  Searches for and returns lyrics for a given song.
 ---
 
 `http://your-server/rest/getLyrics` Since [1.2.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getnewestpodcasts.md
+++ b/content/en/docs/Endpoints/getnewestpodcasts.md
@@ -4,7 +4,7 @@ linkTitle: "getNewestPodcasts"
 categories:
 - Podcast
 description: >
-    Returns the most recently published Podcast episodes.
+  Returns the most recently published Podcast episodes.
 ---
 
 `http://your-server/rest/getNewestPodcasts` Since [1.13.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getnowplaying.md
+++ b/content/en/docs/Endpoints/getnowplaying.md
@@ -4,7 +4,7 @@ linkTitle: "getNowPlaying"
 categories:
 - Lists
 description: >
-    Returns what is currently being played by all users.
+  Returns what is currently being played by all users.
 ---
 
 `http://your-server/rest/getNowPlaying` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getopensubsonicextensions.md
+++ b/content/en/docs/Endpoints/getopensubsonicextensions.md
@@ -6,7 +6,7 @@ categories:
 OpenSubsonic:
 - Addition
 description: >
-    List the OpenSubsonic extensions supported by this server.
+  List the OpenSubsonic extensions supported by this server.
 ---
 
 `http://your-server/rest/getOpenSubsonicExtensions` OpenSubsonic version [1](../../opensubsonic-versions)

--- a/content/en/docs/Endpoints/getplayqueue.md
+++ b/content/en/docs/Endpoints/getplayqueue.md
@@ -4,7 +4,7 @@ linkTitle: "getPlayQueue"
 categories:
 - Bookmarks
 description: >
-    Returns the state of the play queue for this user.
+  Returns the state of the play queue for this user.
 ---
 
 `http://your-server/rest/getPlayQueue` Since [1.12.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getpodcastepisode.md
+++ b/content/en/docs/Endpoints/getpodcastepisode.md
@@ -6,7 +6,7 @@ OpenSubsonic:
 categories:
     - Browsing
 description: >
-    Returns details for a podcast episode.
+  Returns details for a podcast episode.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Endpoints/getpodcasts.md
+++ b/content/en/docs/Endpoints/getpodcasts.md
@@ -4,7 +4,7 @@ linkTitle: "getPodcasts"
 categories:
 - Podcast
 description: >
-    Returns all Podcast channels the server subscribes to, and (optionally) their episodes.
+  Returns all Podcast channels the server subscribes to, and (optionally) their episodes.
 ---
 
 

--- a/content/en/docs/Endpoints/getscanstatus.md
+++ b/content/en/docs/Endpoints/getscanstatus.md
@@ -4,7 +4,7 @@ linkTitle: "getScanStatus"
 categories:
 - Media library scanning
 description: >
-    Returns the current status for media library scanning.
+  Returns the current status for media library scanning.
 ---
 
 `http://your-server/rest/getScanStatus` Since [1.15.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getshares.md
+++ b/content/en/docs/Endpoints/getshares.md
@@ -4,7 +4,7 @@ linkTitle: "getShares"
 categories:
 - Sharing
 description: >
-    Returns information about shared media this user is allowed to manage.
+  Returns information about shared media this user is allowed to manage.
 ---
 
 `http://your-server/rest/getShares` Since [1.6.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getsong.md
+++ b/content/en/docs/Endpoints/getsong.md
@@ -4,7 +4,7 @@ linkTitle: "getSong"
 categories:
 - Browsing
 description: >
-    Returns details for a song.
+  Returns details for a song.
 ---
 
 `http://your-server/rest/getSong` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getsongsbygenre.md
+++ b/content/en/docs/Endpoints/getsongsbygenre.md
@@ -4,7 +4,7 @@ linkTitle: "getSongsByGenre"
 categories:
 - Lists
 description: >
-    Returns songs in a given genre.
+  Returns songs in a given genre.
 ---
 
 `http://your-server/rest/getSongsByGenre` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getstarred.md
+++ b/content/en/docs/Endpoints/getstarred.md
@@ -4,7 +4,7 @@ linkTitle: "getStarred"
 categories:
 - Lists
 description: >
-    Returns starred songs, albums and artists.
+  Returns starred songs, albums and artists.
 ---
 
 `http://your-server/rest/getStarred` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getstarred2.md
+++ b/content/en/docs/Endpoints/getstarred2.md
@@ -4,7 +4,7 @@ linkTitle: "getStarred2"
 categories:
 - Lists
 description: >
-    Returns starred songs, albums and artists.
+  Returns starred songs, albums and artists.
 ---
 
 `http://your-server/rest/getStarred2` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getuser.md
+++ b/content/en/docs/Endpoints/getuser.md
@@ -4,7 +4,7 @@ linkTitle: "getUser"
 categories:
 - User management
 description: >
-    Get details about a given user, including which authorization roles and folder access it has.
+  Get details about a given user, including which authorization roles and folder access it has.
 ---
 
 `http://your-server/rest/getUser` Since [1.3.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getusers.md
+++ b/content/en/docs/Endpoints/getusers.md
@@ -4,7 +4,7 @@ linkTitle: "getUsers"
 categories:
 - User management
 description: >
-    Get details about all users, including which authorization roles and folder access they have
+  Get details about all users, including which authorization roles and folder access they have.
 ---
 
 `http://your-server/rest/getUsers` Since [1.8.0](../../subsonic-versions)
@@ -93,7 +93,6 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
 }
 {{< /tab >}}
 {{< /tabpane >}}
-
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |

--- a/content/en/docs/Endpoints/getvideoinfo.md
+++ b/content/en/docs/Endpoints/getvideoinfo.md
@@ -4,7 +4,7 @@ linkTitle: "getVideoInfo"
 categories:
 - Browsing
 description: >
-    Returns details for a video.
+  Returns details for a video.
 ---
 
 `http://your-server/rest/getVideoInfo` Since [1.14.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/getvideos.md
+++ b/content/en/docs/Endpoints/getvideos.md
@@ -4,7 +4,7 @@ linkTitle: "getVideos"
 categories:
 - Browsing
 description: >
-    Returns all video files.
+  Returns all video files.
 ---
 
 `http://your-server/rest/getVideos` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/hls.md
+++ b/content/en/docs/Endpoints/hls.md
@@ -4,7 +4,7 @@ linkTitle: "hls"
 categories:
 - Media retrieval
 description: >
-    Downloads a given media file.
+  Downloads a given media file.
 ---
 
 `http://your-server/rest/hls.m3u8` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/jukeboxcontrol.md
+++ b/content/en/docs/Endpoints/jukeboxcontrol.md
@@ -4,7 +4,7 @@ linkTitle: "jukeboxControl"
 categories:
 - Jukebox
 description: >
-    Controls the jukebox, i.e., playback directly on the server's audio hardware.
+  Controls the jukebox, i.e., playback directly on the server's audio hardware.
 ---
 
 `http://your-server/rest/jukeboxControl` Since [1.2.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/ping.md
+++ b/content/en/docs/Endpoints/ping.md
@@ -4,7 +4,7 @@ linkTitle: "ping"
 categories:
 - System
 description: >
-    Used to test connectivity with the server. 
+  Used to test connectivity with the server.
 ---
 
 `http://your-server/rest/ping` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/refreshpodcasts.md
+++ b/content/en/docs/Endpoints/refreshpodcasts.md
@@ -4,7 +4,7 @@ linkTitle: "refreshPodcasts"
 categories:
 - Podcast
 description: >
-    Requests the server to check for new Podcast episodes.
+  Requests the server to check for new Podcast episodes.
 ---
 
 `http://your-server/rest/refreshPodcasts` Since [1.9.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/saveplayqueue.md
+++ b/content/en/docs/Endpoints/saveplayqueue.md
@@ -6,7 +6,7 @@ opensubsonic:
 categories:
 - Bookmarks
 description: >
-    Saves the state of the play queue for this user.
+  Saves the state of the play queue for this user.
 ---
 
 `http://your-server/rest/savePlayQueue` Since [1.12.0](../../subsonic-versions)
@@ -55,4 +55,3 @@ An empty [`subsonic-response`](../../responses/subsonic-response) element on suc
 {{< alert color="warning" title="OpenSubsonic" >}}
 **Note** `id` is optional. Send a call without any parameters to clear the currently saved queue.
 {{< /alert >}}
-

--- a/content/en/docs/Endpoints/scrobble.md
+++ b/content/en/docs/Endpoints/scrobble.md
@@ -4,7 +4,7 @@ linkTitle: "scrobble"
 categories:
 - Media annotation
 description: >
-    Registers the local playback of one or more media files.
+  Registers the local playback of one or more media files.
 ---
 
 `http://your-server/rest/scrobble` Since [1.5.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/search.md
+++ b/content/en/docs/Endpoints/search.md
@@ -4,7 +4,7 @@ linkTitle: "search"
 categories:
 - Searching
 description: >
-    Returns a listing of files matching the given search criteria. Supports paging through the result.
+  Returns a listing of files matching the given search criteria. Supports paging through the result.
 ---
 
 `http://your-server/rest/search` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/search2.md
+++ b/content/en/docs/Endpoints/search2.md
@@ -4,7 +4,7 @@ linkTitle: "search2"
 categories:
 - Searching
 description: >
-    Returns a listing of files matching the given search criteria. Supports paging through the result.
+  Returns a listing of files matching the given search criteria. Supports paging through the result.
 ---
 
 `http://your-server/rest/search2` Since [1.4.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -6,7 +6,7 @@ opensubsonic:
 categories:
 - Searching
 description: >
-    Returns albums, artists and songs matching the given search criteria. Supports paging through the result.
+  Returns albums, artists and songs matching the given search criteria. Supports paging through the result.
 ---
 
 `http://your-server/rest/search3` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/setrating.md
+++ b/content/en/docs/Endpoints/setrating.md
@@ -4,7 +4,7 @@ linkTitle: "setRating"
 categories:
 - Media annotation
 description: >
-    Sets the rating for a music file.
+  Sets the rating for a music file.
 ---
 
 `http://your-server/rest/setRating` Since [1.6.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/star.md
+++ b/content/en/docs/Endpoints/star.md
@@ -4,7 +4,7 @@ linkTitle: "star"
 categories:
 - Media annotation
 description: >
-    Attaches a star to a song, album or artist.
+  Attaches a star to a song, album or artist.
 ---
 
 `http://your-server/rest/star` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/startscan.md
+++ b/content/en/docs/Endpoints/startscan.md
@@ -4,7 +4,7 @@ linkTitle: "startScan"
 categories:
 - Media library scanning
 description: >
-    Initiates a rescan of the media libraries.
+  Initiates a rescan of the media libraries.
 ---
 
 `http://your-server/rest/startScan` Since [1.15.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/stream.md
+++ b/content/en/docs/Endpoints/stream.md
@@ -8,7 +8,7 @@ opensubsonic:
 categories:
 - Media retrieval
 description: >
-    Streams a given media file.
+  Streams a given media file.
 ---
 
 `http://your-server/rest/stream` Since [1.0.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/tokeninfo.md
+++ b/content/en/docs/Endpoints/tokeninfo.md
@@ -7,7 +7,7 @@ opensubsonic:
 categories:
   - System
 description: >
-  Returns information about an API key
+  Returns information about an API key.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)
@@ -25,7 +25,6 @@ None
 ### Example
 
 {{< alert color="primary" >}} `http://your-server/rest/tokenInfo.view?apiKey=1234&v=1.13.0&c=AwesomeClientName&f=json` {{< /alert >}}
-
 
 ### Result
 

--- a/content/en/docs/Endpoints/unstar.md
+++ b/content/en/docs/Endpoints/unstar.md
@@ -4,7 +4,7 @@ linkTitle: "unstar"
 categories:
 - Media annotation
 description: >
-    Attaches a star to a song, album or artist.
+  Attaches a star to a song, album or artist.
 ---
 
 `http://your-server/rest/unstar` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/updateinternetradiostation.md
+++ b/content/en/docs/Endpoints/updateinternetradiostation.md
@@ -4,7 +4,7 @@ linkTitle: "updateInternetRadioStation"
 categories:
 - Internet radio
 description: >
-    Updates an existing internet radio station. 
+  Updates an existing internet radio station.
 ---
 
 `http://your-server/rest/updateInternetRadioStation` Since [1.16.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/updateplaylist.md
+++ b/content/en/docs/Endpoints/updateplaylist.md
@@ -4,7 +4,7 @@ linkTitle: "updatePlaylist"
 categories:
 - Playlists
 description: >
-    Updates a playlist. Only the owner of a playlist is allowed to update it.
+  Updates a playlist. Only the owner of a playlist is allowed to update it.
 ---
 
 `http://your-server/rest/updatePlaylist` Since [1.8.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/updateshare.md
+++ b/content/en/docs/Endpoints/updateshare.md
@@ -4,7 +4,7 @@ linkTitle: "updateShare"
 categories:
 - Sharing
 description: >
-    Updates the description and/or expiration date for an existing share.
+  Updates the description and/or expiration date for an existing share.
 ---
 
 `http://your-server/rest/updateShare` Since [1.6.0](../../subsonic-versions)

--- a/content/en/docs/Endpoints/updateuser.md
+++ b/content/en/docs/Endpoints/updateuser.md
@@ -4,7 +4,7 @@ linkTitle: "updateUser"
 categories:
 - User management
 description: >
-    Modifies an existing user on the server.
+  Modifies an existing user on the server.
 ---
 
 `http://your-server/rest/updateUser` Since [1.10.1](../../subsonic-versions)

--- a/content/en/docs/Extensions/TranscodeOffset.md
+++ b/content/en/docs/Extensions/TranscodeOffset.md
@@ -4,7 +4,7 @@ linkTitle: "Transcode Offset"
 OpenSubsonic:
 - Extension
 description: >
-    Add support for start offset for transcoding.
+  Add support for start offset for transcoding.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Extensions/apiKeyAuth.md
+++ b/content/en/docs/Extensions/apiKeyAuth.md
@@ -4,7 +4,7 @@ linkTitle: "API Key Authentication"
 OpenSubsonic:
   - Extension
 description: >
-  Add a new authentication mechanism involving only an API key, and no
+  Add a new authentication mechanism involving only an API key, and no.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Extensions/formPost.md
+++ b/content/en/docs/Extensions/formPost.md
@@ -4,7 +4,7 @@ linkTitle: "HTTP form POST"
 OpenSubsonic:
   - Extension
 description: >
-  Add support for POST request to the API (application/x-www-form-urlencoded)
+  Add support for POST request to the API (application/x-www-form-urlencoded).
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Extensions/getPodcastEpisode.md
+++ b/content/en/docs/Extensions/getPodcastEpisode.md
@@ -4,7 +4,7 @@ linkTitle: "getPodcastEpisode"
 OpenSubsonic:
 - Extension
 description: >
-    Add support for retrieving individual podcast episode metadata
+  Add support for retrieving individual podcast episode metadata.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -4,7 +4,7 @@ linkTitle: "Song Lyrics"
 OpenSubsonic:
   - Extension
 description: >
-  Add support for synchronized lyrics, multiple languages, and retrieval by song ID
+  Add support for synchronized lyrics, multiple languages, and retrieval by song ID.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Extensions/template.md
+++ b/content/en/docs/Extensions/template.md
@@ -4,7 +4,7 @@ linkTitle: "Template extension"
 OpenSubsonic:
 - Extension
 description: >
-    A template extension.
+  A template extension.
 ---
 
 **OpenSubsonic version**: [1](../../opensubsonic-versions)

--- a/content/en/docs/Openapi/_index.md
+++ b/content/en/docs/Openapi/_index.md
@@ -13,20 +13,20 @@ This work is still ongoing, there are some inconsistencies between the docs and 
 
 ## List of known differences compared to official documentation
 
-- Some undocumented typo fixes
-- Added minimum: 0 to integer types where it's implied (count, offset, unix timestamp, position)
-- **Requires the use of `format=json` parameter**. xml response formats are not supported as of the time of writing this document.
-- All extensions are added to the schema and tagged as "Extension", 
-  and have an additional 404 return type as well that described as "Not 
+* Some undocumented typo fixes
+* Added minimum: 0 to integer types where it's implied (count, offset, unix timestamp, position)
+* **Requires the use of `format=json` parameter**. xml response formats are not supported as of the time of writing this document.
+* All extensions are added to the schema and tagged as "Extension",
+  and have an additional 404 return type as well that described as "Not
   Implemented"
-- Excluded examples. They need to be carefully added incrementally to see how they are merged in Swagger/Redoc docs.
-- Parameters only existing via Extensions are always added and marked in their description field
-- HTTP form POST extensions have an additional response "405 - Method 
-  Not Allowed" as an additional way to indicate when they are not 
+* Excluded examples. They need to be carefully added incrementally to see how they are merged in Swagger/Redoc docs.
+* Parameters only existing via Extensions are always added and marked in their description field
+* HTTP form POST extensions have an additional response "405 - Method
+  Not Allowed" as an additional way to indicate when they are not
   supported.
-- HTTP form POST extension support might be stricter than what's 
-  allowed (global params - auth and format params - only allowed as query 
-  params, endpoint specific params are the only ones allowed in request 
+*-* HTTP form POST extension support might be stricter than what's
+  allowed (global params - auth and format params - only allowed as query
+  params, endpoint specific params are the only ones allowed in request
   body)
 
 ## Building
@@ -71,7 +71,7 @@ Ideally this should be used as a reference and for automatic client/server code 
 
 * [openapi-generator](https://github.com/OpenAPITools/openapi-generator) 🚧 - Untested
 
-### C#
+### C\#
 
 * [openapi-generator](https://github.com/OpenAPITools/openapi-generator) 🚧 - Untested
 
@@ -85,7 +85,7 @@ Ideally this should be used as a reference and for automatic client/server code 
 
 ### Folder Structure
 
-* `endpoints`  - matches `paths` section in `openapi.json`, files inside should be added to said section. 
+* `endpoints`  - matches `paths` section in `openapi.json`, files inside should be added to said section.
 
 * `endpoints/{endpoint}.json/{endpoint}/` - supporting schemas for en endpoint, should be added to `components/schemas` section in `openapi.json`
 

--- a/content/en/docs/Responses/AlbumID3WithSongs.md
+++ b/content/en/docs/Responses/AlbumID3WithSongs.md
@@ -4,7 +4,7 @@ linkTitle: "AlbumID3WithSongs [OS]"
 opensubsonic:
 - Change
 description: >
-  Album with songs.
+  An extension of [`AlbumID3`](../albumid3) with song [`Child`](../child) entries.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/ArtistWithAlbumsID3.md
+++ b/content/en/docs/Responses/ArtistWithAlbumsID3.md
@@ -2,7 +2,7 @@
 title: "ArtistWithAlbumsID3"
 linkTitle: "ArtistWithAlbumsID3 [OS]"
 description: >
-  An extension of [`ArtistID3`](../artistid3) with [`AlbumID3`](../albumid3)
+  An extension of [`ArtistID3`](../artistid3) with [`AlbumID3`](../albumid3).
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/Child.md
+++ b/content/en/docs/Responses/Child.md
@@ -211,7 +211,6 @@ description: >
 | `replayGain` | [`ReplayGain`](../replaygain) | No | **Yes**  | The replaygain data of the song. |
 | `explicitStatus` | `string` | No |  **Yes**    | Returns "explicit", "clean" or "". (For songs extracted from tags "ITUNESADVISORY": 1 = explicit, 2 = clean, MP4 "rtng": 1 or 4 = explicit, 2 = clean. See [`albumID3`](../albumid3) for albums) |
 
-
 {{< alert color="warning" title="OpenSubsonic" >}}
 New fields are added:
 

--- a/content/en/docs/Responses/Contributor.md
+++ b/content/en/docs/Responses/Contributor.md
@@ -4,7 +4,7 @@ linkTitle: "Contributor [OS]"
 opensubsonic:
 - Addition
 description: >
-  A contributor artist for a song or an album
+  A contributor artist for a song or an album.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/DiscTitle.md
+++ b/content/en/docs/Responses/DiscTitle.md
@@ -4,7 +4,7 @@ linkTitle: "DiscTitle [OS]"
 opensubsonic:
 - Addition
 description: >
-  A disc title for an album
+  A disc title for an album.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/PodcastChannel.md
+++ b/content/en/docs/Responses/PodcastChannel.md
@@ -2,7 +2,7 @@
 title: "PodcastChannel"
 linkTitle: "PodcastChannel"
 description: >
-  A Podcast channel
+  A Podcast channel.
 ---
 
 {{< tabpane persist=false >}}
@@ -78,7 +78,6 @@ description: >
 }
 {{< /tab >}}
 {{< /tabpane >}}
-
 
 | Field              | Type                                            | Req.    | OpenS. | Details                                   |
 | ------------------ | ----------------------------------------------- | ------- | ------ | ----------------------------------------- |

--- a/content/en/docs/Responses/PodcastEpisode.md
+++ b/content/en/docs/Responses/PodcastEpisode.md
@@ -2,7 +2,7 @@
 title: "PodcastEpisode"
 linkTitle: "PodcastEpisode"
 description: >
-  A Podcast episode
+  A Podcast episode.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/PodcastStatus.md
+++ b/content/en/docs/Responses/PodcastStatus.md
@@ -2,7 +2,7 @@
 title: "PodcastStatus"
 linkTitle: "PodcastStatus"
 description: >
-  An enumeration of possible podcast statuses
+  An enumeration of possible podcast statuses.
 ---
 
 A podcast status is a string type taking one of the following values:

--- a/content/en/docs/Responses/line.md
+++ b/content/en/docs/Responses/line.md
@@ -4,7 +4,7 @@ linkTitle: "line [OS]"
 opensubsonic:
   - Addition
 description: >
-  One line of a song lyric
+  One line of a song lyric.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/lyricsList.md
+++ b/content/en/docs/Responses/lyricsList.md
@@ -4,7 +4,7 @@ linkTitle: "lyricsList [OS]"
 opensubsonic:
   - Addition
 description: >
-  List of structured lyrics
+  List of structured lyrics.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/starred2.md
+++ b/content/en/docs/Responses/starred2.md
@@ -133,6 +133,6 @@ description: >
 
 | Field    | Type                              | Req. | OpenS. | Details         |
 | -------- | --------------------------------- | ---- | ------ | --------------- |
-| `artist` | Array of [`ArtistID3`](../artist) | No   |        | Starred artists |
-| `album`  | Array of [`AlbumID3`](../child)   | No   |        | Starred albums  |
+| `artist` | Array of [`artist`](../artist) | No   |        | Starred artists |
+| `album`  | Array of [`Child`](../child)      | No   |        | Starred albums  |
 | `song`   | Array of [`Child`](../child)      | No   |        | Starred songs   |

--- a/content/en/docs/Responses/structuredLyrics.md
+++ b/content/en/docs/Responses/structuredLyrics.md
@@ -4,7 +4,7 @@ linkTitle: "structuredLyrics [OS]"
 opensubsonic:
   - Addition
 description: >
-  Structured lyrics
+  Structured lyrics.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/Responses/tokeninfo.md
+++ b/content/en/docs/Responses/tokeninfo.md
@@ -4,7 +4,7 @@ linkTitle: "tokenInfo [OS]"
 opensubsonic:
   - Addition
 description: >
-  Information about an API key
+  Information about an API key.
 ---
 
 {{< tabpane persist=false >}}

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -38,7 +38,6 @@ Any server or client can join the organization and make proposals for [OpenSubso
 | [Nextcloud Music / ownCloud Music](https://github.com/owncloud/music)  | [Documentation](https://github.com/owncloud/music/wiki/OpenSubsonic-API)   |
 | [Supysonic](https://github.com/spl0k/supysonic) | - |
 
-
 ### Clients
 
 | Name  | OpenSubsonic documentation  |

--- a/content/en/docs/api-reference.md
+++ b/content/en/docs/api-reference.md
@@ -166,7 +166,6 @@ The following error codes are defined:
 | 60   | The trial period for the Subsonic server is over. Please upgrade to Subsonic Premium. Visit subsonic.org for details. |
 | 70   | The requested data was not found.                                                                                     |
 
-
 {{< alert color="warning" title="OpenSubsonic" >}}
 Servers **must** return error `41` if they do not support token-based authentication, `42` if they do not support any other authentication mechanism (password-based and/or API key-based), and `43` if multiple conflicting authentication parameters are passed in at the same time.
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": "none.js",
   "scripts": {
     "start": "npx hugo server",
-    "build": "npm run build:openapi && npx hugo --gc --minify",
-    "build:openapi": "swagger-cli bundle openapi/openapi.json -o content/en/docs/Openapi/openapi.json --type json && npx vacuum lint content/en/docs/Openapi/openapi.json -d -a -e"
+    "build": "markdownlint 'content/**/*.md' --config .markdownlint.json && npm run build:openapi && npx hugo --gc --minify",
+    "build:openapi": "swagger-cli bundle openapi/openapi.json -o content/en/docs/Openapi/openapi.json --type json && npx vacuum lint content/en/docs/Openapi/openapi.json -d -a -e",
+    "lint:md": "markdownlint 'content/**/*.md' --config .markdownlint.json"
   },
   "repository": {
     "type": "git",
@@ -22,6 +23,7 @@
     "@quobix/vacuum": "^0.16.9",
     "autoprefixer": "^10.4.0",
     "hugo-extended": "0.133.1",
+    "markdownlint-cli": "^0.45.0",
     "postcss": "^8.3.7",
     "postcss-cli": "^9.0.2",
     "swagger-cli": "^4.0.4"


### PR DESCRIPTION
Things that i caught while copy/pasting from the docs to fill my new classes

Description block all indented 2 spaces

```
description: >
  This is a description.
---
```

Description strings all end with .

Link titles references the title of the link

e.g.

![image](https://github.com/user-attachments/assets/b7e939ad-85f2-4ae5-9135-2848d61b2e20)

NPM script lint:md added to run `npx markdownlint "content/en/**/*.md" --config .markdownlint.json`

Missing columns on 2 endpoints and multiline cleanup

Added the markdownlint command to the build script

```
"build": "markdownlint 'content/**/*.md' --config .markdownlint.json && npm run build:openapi && npx hugo --gc --minify",
```