### PR TITLE
Add measurementScheme field to ReplayGain Response

### DIFF
--- a/content/en/docs/Responses/ReplayGain.md
+++ b/content/en/docs/Responses/ReplayGain.md
@@ -32,6 +32,7 @@ Does not exist.
 | `albumPeak` | `number` | No | **Yes**    | The album peak value. (Must be positive) |
 | `baseGain` | `number` | No | **Yes**    | The base gain value. (In Db) (Ogg Opus Output Gain for example) |
 | `fallbackGain` | `number` | No | **Yes**    | An optional fallback gain that clients should apply when the corresponding gain value is missing. (Can be computed from the tracks or exposed as an user setting.) |
+| `measurementScheme` | `string` | No | **Yes** | The name of the measurement scheme used to calculate gain values. Valid values are 'ReplayGain', 'ReplayGainV2', 'EBUR128'. |
 
 **Note**: If the data is not present the field must be ommited in the answer. (But the replayGain field on [`Child`](../child) must always be present)
 

--- a/openapi/schemas/ReplayGain.json
+++ b/openapi/schemas/ReplayGain.json
@@ -27,6 +27,10 @@
         "fallbackGain": {
             "type": "number",
             "description": "An optional fallback gain that clients should apply when the corresponding gain value is missing. (Can be computed from the tracks or exposed as an user setting.)"
+        },
+        "measurementScheme": {
+            "type": "string",
+            "description": "The name of the measurement scheme used to calculate gain values. Valid values are 'ReplayGain', 'ReplayGainV2', 'EBUR128'."
         }
     },
     "externalDocs": {


### PR DESCRIPTION
The values presented by the ReplayGain object can be misinterpreted without knowing the standard used in calculating them. It is my understanding that while these values are all measured in decibles, the standards used for calculating them make ReplayGain incompatible with the ReplayGainV2 and EBUR128, but there may be a conversion rate or factor between ReplayGainV2 and EBUR128. However, I am still not entirely cleanr on the relationships between the three standards. However, a play back application could misinterpret the values leading to unexpected behavoir.

It is not clear to me if we should specify how a client should interpret the lack of this field or if that can be left up to individual clients or users.

See: https://github.com/opensubsonic/open-subsonic-api/discussions/165