### PR TITLE
resolve spelling errors in /content documentation

### DIFF
--- a/content/en/docs/Endpoints/createuser.md
+++ b/content/en/docs/Endpoints/createuser.md
@@ -18,7 +18,7 @@ Creates a new user on the server, using the following parameters:
 | `username` | **Yes** |  |   | The name of the new user. |
 | `password` | **Yes** |  |   | The password of the new user, either in clear text of hex-encoded (see above). |
 | `email` | **Yes** |   |  | The email address of the new user. |
-| `ldapAuthenticated` | No  || false | Whether the user is authenicated in LDAP. |
+| `ldapAuthenticated` | No  || false | Whether the user is authenticated in LDAP. |
 | `adminRole` | No  | |false | Whether the user is administrator. |
 | `settingsRole` | No  | |true | Whether the user is allowed to change personal settings and password. |
 | `streamRole` | No  || true | Whether the user is allowed to play files. |

--- a/content/en/docs/Endpoints/getnewestpodcasts.md
+++ b/content/en/docs/Endpoints/getnewestpodcasts.md
@@ -106,4 +106,4 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
-| `newestPodcasts` | [`NewestPodcasts`](../../responses/newestpodcasts) | **Yes** |     | The podacsts |
+| `newestPodcasts` | [`NewestPodcasts`](../../responses/newestpodcasts) | **Yes** |     | The podcasts |

--- a/content/en/docs/Endpoints/getpodcasts.md
+++ b/content/en/docs/Endpoints/getpodcasts.md
@@ -119,4 +119,4 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
-| `podcasts` | [`podcasts`](../../responses/podcasts) | **Yes** |     | The podacsts |
+| `podcasts` | [`podcasts`](../../responses/podcasts) | **Yes** |     | The podcasts |

--- a/content/en/docs/Endpoints/search.md
+++ b/content/en/docs/Endpoints/search.md
@@ -18,7 +18,7 @@ Returns a listing of files matching the given search criteria. Supports paging t
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
 | `artist` | No  ||       | Artist to search for. |
-| `album` | No  | |      | Album to searh for. |
+| `album` | No  | |      | Album to search for. |
 | `title` | No  | |      | Song title to search for. |
 | `any` | No  |  |     | Searches all fields. |
 | `count` | No  | |  20  | Maximum number of results to return. |

--- a/content/en/docs/Endpoints/stream.md
+++ b/content/en/docs/Endpoints/stream.md
@@ -22,7 +22,7 @@ Streams a given media file.
 | `id` | **Yes** | |     | A string which uniquely identifies the file to stream. Obtained by calls to getMusicDirectory. |
 | `maxBitRate` | No |  |     | (Since [1.2.0](../../subsonic-versions)) If specified, the server will attempt to limit the bitrate to this value, in kilobits per second. If set to zero, no limit is imposed. |
 | `format` | No |  |     | (Since [1.6.0](../../subsonic-versions)) Specifies the preferred target format (e.g., "mp3" or "flv") in case there are multiple applicable transcodings. Starting with [1.9.0](../../subsonic-versions) you can use the special value "raw" to disable transcoding. |
-| `timeOffset` | No| No / **Yes**   |     | By default only applicable to video streaming. If specified, start streaming at the given offset (in seconds) into the media. The [`Transcode Offet`](../../extensions/transcodeoffset/) extension enables the parameter to music too. |
+| `timeOffset` | No| No / **Yes**   |     | By default only applicable to video streaming. If specified, start streaming at the given offset (in seconds) into the media. The [`Transcode Offset`](../../extensions/transcodeoffset/) extension enables the parameter to music too. |
 | `size` | No  |   |   | (Since [1.6.0](../../subsonic-versions)) Only applicable to video streaming. Requested video size specified as WxH, for instance "640x480". |
 | `estimateContentLength` | No |  | false | (Since [1.8.0](../../subsonic-versions)). If set to "true", the *Content-Length* HTTP header will be set to an estimated value for transcoded or downsampled media. |
 | `converted` | No  | | false | (Since [1.14.0](../../subsonic-versions)) Only applicable to video streaming. Servers can optimize videos for streaming by converting them to MP4. If a conversion exists for the video in question, then setting this parameter to "true" will cause the converted video to be returned instead of the original. |
@@ -38,6 +38,6 @@ Returns binary data on success, or an XML document on error (in which case the H
 {{< alert color="warning" title="OpenSubsonic" >}}
 OpenSubsonic servers **must not** count access to this endpoint as a play and increase playcount. Clients can use the [`Scrobble`](../scrobble) endpoint to indicate that a media is played ensuring proper data in all cases.
 
-If the server support the [`Transcode Offet`](../../extensions/transcodeoffset/) extension, then it must accept the `timeOffset` parameter for music too.
+If the server support the [`Transcode Offset`](../../extensions/transcodeoffset/) extension, then it must accept the `timeOffset` parameter for music too.
 
 {{< /alert >}}

--- a/content/en/docs/Endpoints/updateuser.md
+++ b/content/en/docs/Endpoints/updateuser.md
@@ -18,7 +18,7 @@ Modifies an existing user on the server.
 | `username` | **Yes** |  |     | The name of the user. |
 | `password` | No  |   |    | The password of the user, either in clear text of hex-encoded (see above). |
 | `email` | No  |   |    | The email address of the user. |
-| `ldapAuthenticated` | No  | |      | Whether the user is authenicated in LDAP. |
+| `ldapAuthenticated` | No  | |      | Whether the user is authenticated in LDAP. |
 | `adminRole` | No  |   |    | Whether the user is administrator. |
 | `settingsRole` | No  |  |     | Whether the user is allowed to change personal settings and password. |
 | `streamRole` | No  |   |    | Whether the user is allowed to play files. |

--- a/content/en/docs/Responses/DiscTitle.md
+++ b/content/en/docs/Responses/DiscTitle.md
@@ -22,7 +22,7 @@ Does not exist.
 
 | Field |  Type | Req. | OpenS. | Details |
 | --- | --- | --- | --- | --- |
-| `disc` | `int` | **Yes** | **Yes**    | The disc numer. |
+| `disc` | `int` | **Yes** | **Yes**    | The disc number. |
 | `title` | `string` | **Yes**  | **Yes**     | The name of the disc. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}

--- a/content/en/docs/Responses/ReplayGain.md
+++ b/content/en/docs/Responses/ReplayGain.md
@@ -33,7 +33,7 @@ Does not exist.
 | `baseGain` | `number` | No | **Yes**    | The base gain value. (In Db) (Ogg Opus Output Gain for example) |
 | `fallbackGain` | `number` | No | **Yes**    | An optional fallback gain that clients should apply when the corresponding gain value is missing. (Can be computed from the tracks or exposed as an user setting.) |
 
-**Note**: If the data is not present the field must be ommited in the answer. (But the replayGain field on [`Child`](../child) must always be present)
+**Note**: If the data is not present the field must be omitted in the answer. (But the replayGain field on [`Child`](../child) must always be present)
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type.

--- a/content/en/docs/opensubsonic-changes.md
+++ b/content/en/docs/opensubsonic-changes.md
@@ -32,7 +32,7 @@ To achieve this servers supporting OpenSubsonic have to support a very minimal s
 
 1. Expand the [`subsonic-response`](../responses/subsonic-response) with the new mandatory fields.
 2. Implement the [`getOpenSubsonicExtensions`](../endpoints/getopensubsonicextensions) endpoint. This **must** be accessible without any authentication parameters
-3. Return error **41** ([`API Reference`](../api-reference#error-handling)) if they do not support Subsonic [1.13.0](../subsonic-versions) new authentification system while advertising a version > [1.13.0](../subsonic-versions)
+3. Return error **41** ([`API Reference`](../api-reference#error-handling)) if they do not support Subsonic [1.13.0](../subsonic-versions) new authentication system while advertising a version > [1.13.0](../subsonic-versions)
 
 ## List of changes
 


### PR DESCRIPTION
- resolves a small number of typos I noticed whilst using the documentation