### PR TITLE
feat(songLyrics): add cue byte offsets

### DIFF
--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -23,7 +23,7 @@ The lyrics can come from embedded tags (`SYLT`/`USLT`), LRC file/text file, or a
 | Parameter  | Req.    | OpenS.  | Default | Comment                                                                                                                                                |
 | ---------- | ------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `id`       | **Yes** | **Yes** |         | The track ID.                                                                                                                                          |
-| `enhanced` | No      | **Yes** | `false` | When `true`, the response includes [`cueLine`](../../responses/cueline) arrays, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and non-main [`kind`](../../responses/structuredlyrics) tracks (translations, pronunciations). When `false` or omitted, only `kind="main"` entries are returned with no `cueLine` data. Added in [`songLyrics`](../../extensions/songlyrics) version 2. |
+| `enhanced` | No      | **Yes** | `false` | When `true`, the response includes [`cueLine`](../../responses/cueline) arrays, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and non-main [`kind`](../../responses/structuredlyrics) tracks (translations, pronunciations). When `false` or omitted, only `kind="main"` entries are returned with no `cueLine` data. Added in [`songLyrics`](../../extensions/songlyrics) version 2. |
 
 {{< alert color="warning" title="Special notes about the lang field" >}}
 Ideally, the server will return `lang` as an ISO 639 (2/3) code.
@@ -123,7 +123,7 @@ Does not exist.
 
 #### Version 2 (`enhanced=true`)
 
-When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value` for ambiguous repeated text, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
+When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
 
 {{< alert color="primary" >}} `http://your-server/rest/getLyricsBySongId.view?id=456&enhanced=true&u=demo&p=demo&v=1.13.0&c=AwesomeClientName&f=json` {{< /alert >}}
 
@@ -154,13 +154,13 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
               "end": 6214,
               "value": "눈을 뜬 순간",
               "cue": [
-                { "start": 2747, "end": 3018, "value": "눈" },
-                { "start": 3018, "end": 3179, "value": "을" },
-                { "start": 3179, "end": 3582, "value": " " },
-                { "start": 3582, "end": 4100, "value": "뜬" },
-                { "start": 4100, "end": 4500, "value": " " },
-                { "start": 4500, "end": 5200, "value": "순" },
-                { "start": 5200, "end": 6214, "value": "간" }
+                { "start": 2747, "end": 3018, "value": "눈", "byteStart": 0, "byteEnd": 2 },
+                { "start": 3018, "end": 3179, "value": "을", "byteStart": 3, "byteEnd": 5 },
+                { "start": 3179, "end": 3582, "value": " ", "byteStart": 6, "byteEnd": 6 },
+                { "start": 3582, "end": 4100, "value": "뜬", "byteStart": 7, "byteEnd": 9 },
+                { "start": 4100, "end": 4500, "value": " ", "byteStart": 10, "byteEnd": 10 },
+                { "start": 4500, "end": 5200, "value": "순", "byteStart": 11, "byteEnd": 13 },
+                { "start": 5200, "end": 6214, "value": "간", "byteStart": 14, "byteEnd": 16 }
               ]
             },
             {
@@ -169,12 +169,12 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
               "end": 9000,
               "value": "모든 게 달라졌어",
               "cue": [
-                { "start": 6214, "end": 6800, "value": "모" },
-                { "start": 6800, "end": 7200, "value": "든" },
-                { "start": 7200, "end": 7600, "value": " " },
-                { "start": 7600, "end": 8000, "value": "게" },
-                { "start": 8000, "end": 8400, "value": " " },
-                { "start": 8400, "end": 9000, "value": "달라졌어" }
+                { "start": 6214, "end": 6800, "value": "모", "byteStart": 0, "byteEnd": 2 },
+                { "start": 6800, "end": 7200, "value": "든", "byteStart": 3, "byteEnd": 5 },
+                { "start": 7200, "end": 7600, "value": " ", "byteStart": 6, "byteEnd": 6 },
+                { "start": 7600, "end": 8000, "value": "게", "byteStart": 7, "byteEnd": 9 },
+                { "start": 8000, "end": 8400, "value": " ", "byteStart": 10, "byteEnd": 10 },
+                { "start": 8400, "end": 9000, "value": "달라졌어", "byteStart": 11, "byteEnd": 22 }
               ]
             }
           ]
@@ -201,20 +201,22 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
               "index": 0,
               "start": 2747,
               "end": 6214,
+              "value": "nuneul tteun sungan",
               "cue": [
-                { "start": 2747, "end": 3179, "value": "nuneul" },
-                { "start": 3582, "end": 4100, "value": "tteun" },
-                { "start": 4500, "end": 6214, "value": "sungan" }
+                { "start": 2747, "end": 3179, "value": "nuneul", "byteStart": 0, "byteEnd": 5 },
+                { "start": 3582, "end": 4100, "value": "tteun", "byteStart": 7, "byteEnd": 11 },
+                { "start": 4500, "end": 6214, "value": "sungan", "byteStart": 13, "byteEnd": 18 }
               ]
             },
             {
               "index": 1,
               "start": 6214,
               "end": 9000,
+              "value": "modeun ge dallajyeosseo",
               "cue": [
-                { "start": 6214, "end": 7200, "value": "modeun" },
-                { "start": 7600, "end": 8000, "value": "ge" },
-                { "start": 8400, "end": 9000, "value": "dallajyeosseo" }
+                { "start": 6214, "end": 7200, "value": "modeun", "byteStart": 0, "byteEnd": 5 },
+                { "start": 7600, "end": 8000, "value": "ge", "byteStart": 7, "byteEnd": 8 },
+                { "start": 8400, "end": 9000, "value": "dallajyeosseo", "byteStart": 10, "byteEnd": 22 }
               ]
             }
           ]
@@ -231,21 +233,21 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
       <line start="2747">눈을 뜬 순간</line>
       <line start="6214">모든 게 달라졌어</line>
       <cueLine index="0" start="2747" end="6214" value="눈을 뜬 순간">
-        <cue start="2747" end="3018">눈</cue>
-        <cue start="3018" end="3179">을</cue>
-        <cue start="3179" end="3582"> </cue>
-        <cue start="3582" end="4100">뜬</cue>
-        <cue start="4100" end="4500"> </cue>
-        <cue start="4500" end="5200">순</cue>
-        <cue start="5200" end="6214">간</cue>
+        <cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
+        <cue start="3018" end="3179" byteStart="3" byteEnd="5">을</cue>
+        <cue start="3179" end="3582" byteStart="6" byteEnd="6"> </cue>
+        <cue start="3582" end="4100" byteStart="7" byteEnd="9">뜬</cue>
+        <cue start="4100" end="4500" byteStart="10" byteEnd="10"> </cue>
+        <cue start="4500" end="5200" byteStart="11" byteEnd="13">순</cue>
+        <cue start="5200" end="6214" byteStart="14" byteEnd="16">간</cue>
       </cueLine>
       <cueLine index="1" start="6214" end="9000" value="모든 게 달라졌어">
-        <cue start="6214" end="6800">모</cue>
-        <cue start="6800" end="7200">든</cue>
-        <cue start="7200" end="7600"> </cue>
-        <cue start="7600" end="8000">게</cue>
-        <cue start="8000" end="8400"> </cue>
-        <cue start="8400" end="9000">달라졌어</cue>
+        <cue start="6214" end="6800" byteStart="0" byteEnd="2">모</cue>
+        <cue start="6800" end="7200" byteStart="3" byteEnd="5">든</cue>
+        <cue start="7200" end="7600" byteStart="6" byteEnd="6"> </cue>
+        <cue start="7600" end="8000" byteStart="7" byteEnd="9">게</cue>
+        <cue start="8000" end="8400" byteStart="10" byteEnd="10"> </cue>
+        <cue start="8400" end="9000" byteStart="11" byteEnd="22">달라졌어</cue>
       </cueLine>
     </structuredLyrics>
     <structuredLyrics kind="translation" lang="eng" synced="true">
@@ -255,15 +257,15 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
     <structuredLyrics kind="pronunciation" lang="ko-Latn" synced="true">
       <line start="2747">nuneul tteun sungan</line>
       <line start="6214">modeun ge dallajyeosseo</line>
-      <cueLine index="0" start="2747" end="6214">
-        <cue start="2747" end="3179">nuneul</cue>
-        <cue start="3582" end="4100">tteun</cue>
-        <cue start="4500" end="6214">sungan</cue>
+      <cueLine index="0" start="2747" end="6214" value="nuneul tteun sungan">
+        <cue start="2747" end="3179" byteStart="0" byteEnd="5">nuneul</cue>
+        <cue start="3582" end="4100" byteStart="7" byteEnd="11">tteun</cue>
+        <cue start="4500" end="6214" byteStart="13" byteEnd="18">sungan</cue>
       </cueLine>
-      <cueLine index="1" start="6214" end="9000">
-        <cue start="6214" end="7200">modeun</cue>
-        <cue start="7600" end="8000">ge</cue>
-        <cue start="8400" end="9000">dallajyeosseo</cue>
+      <cueLine index="1" start="6214" end="9000" value="modeun ge dallajyeosseo">
+        <cue start="6214" end="7200" byteStart="0" byteEnd="5">modeun</cue>
+        <cue start="7600" end="8000" byteStart="7" byteEnd="8">ge</cue>
+        <cue start="8400" end="9000" byteStart="10" byteEnd="22">dallajyeosseo</cue>
       </cueLine>
     </structuredLyrics>
   </lyricsList>
@@ -294,8 +296,8 @@ When a source distinguishes both a lead/default vocal layer and background vocal
       "end": 3000,
       "value": "Hello echo",
       "cue": [
-        { "start": 1000, "end": 1400, "value": "He" },
-        { "start": 1400, "end": 1800, "value": "llo" }
+        { "start": 1000, "end": 1400, "value": "He", "byteStart": 0, "byteEnd": 1 },
+        { "start": 1400, "end": 1800, "value": "llo", "byteStart": 2, "byteEnd": 4 }
       ]
     },
     {
@@ -305,7 +307,7 @@ When a source distinguishes both a lead/default vocal layer and background vocal
       "end": 3000,
       "value": "Hello echo",
       "cue": [
-        { "start": 2000, "end": 2500, "value": "echo" }
+        { "start": 2000, "end": 2500, "value": "echo", "byteStart": 6, "byteEnd": 9 }
       ]
     }
   ]
@@ -315,11 +317,11 @@ When a source distinguishes both a lead/default vocal layer and background vocal
 <agent id="lead" role="main" name="Lead Vocal" />
 <agent id="backing" role="bg" />
 <cueLine index="0" agentId="lead" start="1000" end="3000" value="Hello echo">
-  <cue start="1000" end="1400">He</cue>
-  <cue start="1400" end="1800">llo</cue>
+  <cue start="1000" end="1400" byteStart="0" byteEnd="1">He</cue>
+  <cue start="1400" end="1800" byteStart="2" byteEnd="4">llo</cue>
 </cueLine>
 <cueLine index="0" agentId="backing" start="1000" end="3000" value="Hello echo">
-  <cue start="2000" end="2500">echo</cue>
+  <cue start="2000" end="2500" byteStart="6" byteEnd="9">echo</cue>
 </cueLine>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -348,9 +350,9 @@ When a source has multiple named singers (e.g. a duet from TTML with `ttm:agent`
       "end": 4000,
       "value": "You and I",
       "cue": [
-        { "start": 1000, "end": 1800, "value": "You " },
-        { "start": 1800, "end": 2400, "value": "and " },
-        { "start": 2400, "end": 3200, "value": "I" }
+        { "start": 1000, "end": 1800, "value": "You ", "byteStart": 0, "byteEnd": 3 },
+        { "start": 1800, "end": 2400, "value": "and ", "byteStart": 4, "byteEnd": 7 },
+        { "start": 2400, "end": 3200, "value": "I", "byteStart": 8, "byteEnd": 8 }
       ]
     },
     {
@@ -360,10 +362,10 @@ When a source has multiple named singers (e.g. a duet from TTML with `ttm:agent`
       "end": 7000,
       "value": "Under this sky",
       "cue": [
-        { "start": 4000, "end": 4800, "value": "Un" },
-        { "start": 4800, "end": 5400, "value": "der " },
-        { "start": 5400, "end": 5900, "value": "this " },
-        { "start": 5900, "end": 7000, "value": "sky" }
+        { "start": 4000, "end": 4800, "value": "Un", "byteStart": 0, "byteEnd": 1 },
+        { "start": 4800, "end": 5400, "value": "der ", "byteStart": 2, "byteEnd": 5 },
+        { "start": 5400, "end": 5900, "value": "this ", "byteStart": 6, "byteEnd": 10 },
+        { "start": 5900, "end": 7000, "value": "sky", "byteStart": 11, "byteEnd": 13 }
       ]
     },
     {
@@ -373,10 +375,10 @@ When a source has multiple named singers (e.g. a duet from TTML with `ttm:agent`
       "end": 10000,
       "value": "Together tonight",
       "cue": [
-        { "start": 7000, "end": 8000, "value": "To" },
-        { "start": 8000, "end": 8800, "value": "ge" },
-        { "start": 8800, "end": 9200, "value": "ther " },
-        { "start": 9200, "end": 10000, "value": "tonight" }
+        { "start": 7000, "end": 8000, "value": "To", "byteStart": 0, "byteEnd": 1 },
+        { "start": 8000, "end": 8800, "value": "ge", "byteStart": 2, "byteEnd": 3 },
+        { "start": 8800, "end": 9200, "value": "ther ", "byteStart": 4, "byteEnd": 8 },
+        { "start": 9200, "end": 10000, "value": "tonight", "byteStart": 9, "byteEnd": 15 }
       ]
     }
   ]
@@ -387,21 +389,21 @@ When a source has multiple named singers (e.g. a duet from TTML with `ttm:agent`
 <agent id="guest" role="voice" name="Jin" />
 <agent id="choir" role="group" name="All" />
 <cueLine index="0" agentId="lead" start="1000" end="4000" value="You and I">
-  <cue start="1000" end="1800">You </cue>
-  <cue start="1800" end="2400">and </cue>
-  <cue start="2400" end="3200">I</cue>
+  <cue start="1000" end="1800" byteStart="0" byteEnd="3">You </cue>
+  <cue start="1800" end="2400" byteStart="4" byteEnd="7">and </cue>
+  <cue start="2400" end="3200" byteStart="8" byteEnd="8">I</cue>
 </cueLine>
 <cueLine index="1" agentId="guest" start="4000" end="7000" value="Under this sky">
-  <cue start="4000" end="4800">Un</cue>
-  <cue start="4800" end="5400">der </cue>
-  <cue start="5400" end="5900">this </cue>
-  <cue start="5900" end="7000">sky</cue>
+  <cue start="4000" end="4800" byteStart="0" byteEnd="1">Un</cue>
+  <cue start="4800" end="5400" byteStart="2" byteEnd="5">der </cue>
+  <cue start="5400" end="5900" byteStart="6" byteEnd="10">this </cue>
+  <cue start="5900" end="7000" byteStart="11" byteEnd="13">sky</cue>
 </cueLine>
 <cueLine index="2" agentId="choir" start="7000" end="10000" value="Together tonight">
-  <cue start="7000" end="8000">To</cue>
-  <cue start="8000" end="8800">ge</cue>
-  <cue start="8800" end="9200">ther </cue>
-  <cue start="9200" end="10000">tonight</cue>
+  <cue start="7000" end="8000" byteStart="0" byteEnd="1">To</cue>
+  <cue start="8000" end="8800" byteStart="2" byteEnd="3">ge</cue>
+  <cue start="8800" end="9200" byteStart="4" byteEnd="8">ther </cue>
+  <cue start="9200" end="10000" byteStart="9" byteEnd="15">tonight</cue>
 </cueLine>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -472,7 +474,7 @@ Servers that don't support TTML or word-level timing simply never include these 
 - `agents` are scoped to a single `structuredLyrics` entry. When present, `agents` **must** contain at least one entry, and each `agents[].id` **must** be unique within that entry. `agents` are optional for simple unattributed single-layer lyrics. When a `structuredLyrics` entry represents multiple vocal agents/layers, it **must** include `agents`; a single-agent attributed/default entry may also include `agents`, and if it does, exactly one agent **must** use `role: "main"`. `agents` should not be emitted without `cueLine` data.
 - When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first. Clients should not assume every source can distinguish or emit multiple agents.
 - If `agents` is present, every `cueLine` in that entry **must** include `agentId`, and each `agentId` **must** match exactly one `agents[].id` in that entry. If `agents` is absent, cueLines **must not** include `agentId`.
-- `byteStart` / `byteEnd` on a cue are optional, but when present they **must** appear together, the parent `cueLine` **must** include `value`, they are 0-based inclusive offsets into the final UTF-8 encoding of that `cueLine.value` with no normalization step, and `byteStart` **must** be ≤ `byteEnd`. This is a documented contract rule; the OpenAPI schema does not encode the pairing or cross-field consistency structurally.
+- Every cue **must** include `byteStart` / `byteEnd`, and every `cueLine` **must** include `value`. The offsets are 0-based inclusive positions into the final UTF-8 encoding of that `cueLine.value`, with no normalization step, and `byteStart` **must** be ≤ `byteEnd`. The OpenAPI schema enforces the presence of these fields, but not the cross-field ordering constraint structurally.
 - Cues within a `cueLine` **must not** overlap (i.e. `cue[n].end` **must** be ≤ `cue[n+1].start`). Servers **must** normalize any source overlaps so that clients can iterate cues sequentially without overlap-resolution logic. Overlapping timing across different cueLines (different `agentId` values) is expected, since those represent parallel vocal layers.
 - Cues where `start == end` (zero-duration) may occur. Clients should treat these as instantaneous markers.
 - `structuredLyrics` entries are independent across `kind` tracks, including `main`. Clients should not assume 1:1 correspondence of `line` arrays or `cueLine` arrays between tracks.

--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -23,7 +23,7 @@ The lyrics can come from embedded tags (`SYLT`/`USLT`), LRC file/text file, or a
 | Parameter  | Req.    | OpenS.  | Default | Comment                                                                                                                                                |
 | ---------- | ------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `id`       | **Yes** | **Yes** |         | The track ID.                                                                                                                                          |
-| `enhanced` | No      | **Yes** | `false` | When `true`, the response includes [`cueLine`](../../responses/cueline) arrays and non-main [`kind`](../../responses/structuredlyrics) tracks (translations, pronunciations). When `false` or omitted, only `kind="main"` entries are returned with no `cueLine` data. Added in [`songLyrics`](../../extensions/songlyrics) version 2. |
+| `enhanced` | No      | **Yes** | `false` | When `true`, the response includes [`cueLine`](../../responses/cueline) arrays, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and non-main [`kind`](../../responses/structuredlyrics) tracks (translations, pronunciations). When `false` or omitted, only `kind="main"` entries are returned with no `cueLine` data. Added in [`songLyrics`](../../extensions/songlyrics) version 2. |
 
 {{< alert color="warning" title="Special notes about the lang field" >}}
 Ideally, the server will return `lang` as an ISO 639 (2/3) code.
@@ -123,7 +123,7 @@ Does not exist.
 
 #### Version 2 (`enhanced=true`)
 
-When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
+When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value` for ambiguous repeated text, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
 
 {{< alert color="primary" >}} `http://your-server/rest/getLyricsBySongId.view?id=456&enhanced=true&u=demo&p=demo&v=1.13.0&c=AwesomeClientName&f=json` {{< /alert >}}
 
@@ -409,6 +409,43 @@ Does not exist.
 {{< /tab >}}
 {{< /tabpane >}}
 
+##### Example with ambiguous repeated text
+
+When `cueLine.value` contains untimed text between timed cues, `byteStart` / `byteEnd` identifies the exact substring each timed cue covers:
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
+{
+  "cueLine": [
+    {
+      "index": 0,
+      "start": 0,
+      "end": 2400,
+      "value": "Oh love love me tonight",
+      "cue": [
+        { "start": 0, "end": 300, "value": "Oh", "byteStart": 0, "byteEnd": 1 },
+        { "start": 900, "end": 1300, "value": "love", "byteStart": 8, "byteEnd": 11 },
+        { "start": 1300, "end": 1600, "value": "me", "byteStart": 13, "byteEnd": 14 },
+        { "start": 1600, "end": 2400, "value": "tonight", "byteStart": 16, "byteEnd": 22 }
+      ]
+    }
+  ]
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
+<cueLine index="0" start="0" end="2400" value="Oh love love me tonight">
+  <cue start="0" end="300" byteStart="0" byteEnd="1">Oh</cue>
+  <cue start="900" end="1300" byteStart="8" byteEnd="11">love</cue>
+  <cue start="1300" end="1600" byteStart="13" byteEnd="14">me</cue>
+  <cue start="1600" end="2400" byteStart="16" byteEnd="22">tonight</cue>
+</cueLine>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
 ### Response fields
 
 | Field        | Type                          | Req.    | OpenS.  | Details                   |
@@ -435,6 +472,7 @@ Servers that don't support TTML or word-level timing simply never include these 
 - `agents` are scoped to a single `structuredLyrics` entry. When present, `agents` **must** contain at least one entry, and each `agents[].id` **must** be unique within that entry. `agents` are optional for simple unattributed single-layer lyrics. When a `structuredLyrics` entry represents multiple vocal agents/layers, it **must** include `agents`; a single-agent attributed/default entry may also include `agents`, and if it does, exactly one agent **must** use `role: "main"`. `agents` should not be emitted without `cueLine` data.
 - When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first. Clients should not assume every source can distinguish or emit multiple agents.
 - If `agents` is present, every `cueLine` in that entry **must** include `agentId`, and each `agentId` **must** match exactly one `agents[].id` in that entry. If `agents` is absent, cueLines **must not** include `agentId`.
+- `byteStart` / `byteEnd` on a cue are optional, but when present they **must** appear together, the parent `cueLine` **must** include `value`, they are 0-based inclusive offsets into the final UTF-8 encoding of that `cueLine.value` with no normalization step, and `byteStart` **must** be ≤ `byteEnd`. This is a documented contract rule; the OpenAPI schema does not encode the pairing or cross-field consistency structurally.
 - Cues within a `cueLine` **must not** overlap (i.e. `cue[n].end` **must** be ≤ `cue[n+1].start`). Servers **must** normalize any source overlaps so that clients can iterate cues sequentially without overlap-resolution logic. Overlapping timing across different cueLines (different `agentId` values) is expected, since those represent parallel vocal layers.
 - Cues where `start == end` (zero-duration) may occur. Clients should treat these as instantaneous markers.
 - `structuredLyrics` entries are independent across `kind` tracks, including `main`. Clients should not assume 1:1 correspondence of `line` arrays or `cueLine` arrays between tracks.

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -30,11 +30,11 @@ Adds:
 - [`agent`](../../responses/agent) objects within an optional `agents` array on [`structuredLyrics`](../../responses/structuredlyrics) for reusable agent attribution metadata
 - [`cueLine`](../../responses/cueline) array on [`structuredLyrics`](../../responses/structuredlyrics) for word/syllable-level timing
 - `agentId` field on [`cueLine`](../../responses/cueline) to reference an [`agent`](../../responses/agent) in the same `structuredLyrics` entry
-- [`cue`](../../responses/cue) objects within each `cueLine` for individual word/syllable timestamps, with optional `byteStart` / `byteEnd` offsets into `cueLine.value` when repeated timed and untimed text would otherwise be ambiguous
+- [`cue`](../../responses/cue) objects within each `cueLine` for individual word/syllable timestamps, with required `byteStart` / `byteEnd` offsets into `cueLine.value`
 
 When agent attribution is present, the reusable agent metadata lives once in `structuredLyrics.agents`, while each `cueLine` points at the relevant agent via `agentId`. Simple unattributed single-layer lyrics may omit `agents` entirely. Entries with multiple vocal agents/layers **must** emit `agents`, and every attributed entry that uses `agents` **must** define exactly one `role: "main"` agent. A single-agent attributed/default layer may also use `agents` with that lone agent marked as `main`.
 
-When a cue includes `byteStart` / `byteEnd`, they are defined as 0-based inclusive offsets into the UTF-8 encoding of the final parent `cueLine.value`, with no normalization step.
+Each cue includes `byteStart` / `byteEnd`, defined as 0-based inclusive offsets into the UTF-8 encoding of the final parent `cueLine.value`, with no normalization step. Accordingly, each `cueLine` that contains cues must also include `value`.
 
 All new fields are gated behind `enhanced=true` — without it, the response is identical to version 1.
 

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -30,9 +30,11 @@ Adds:
 - [`agent`](../../responses/agent) objects within an optional `agents` array on [`structuredLyrics`](../../responses/structuredlyrics) for reusable agent attribution metadata
 - [`cueLine`](../../responses/cueline) array on [`structuredLyrics`](../../responses/structuredlyrics) for word/syllable-level timing
 - `agentId` field on [`cueLine`](../../responses/cueline) to reference an [`agent`](../../responses/agent) in the same `structuredLyrics` entry
-- [`cue`](../../responses/cue) objects within each `cueLine` for individual word/syllable timestamps
+- [`cue`](../../responses/cue) objects within each `cueLine` for individual word/syllable timestamps, with optional `byteStart` / `byteEnd` offsets into `cueLine.value` when repeated timed and untimed text would otherwise be ambiguous
 
 When agent attribution is present, the reusable agent metadata lives once in `structuredLyrics.agents`, while each `cueLine` points at the relevant agent via `agentId`. Simple unattributed single-layer lyrics may omit `agents` entirely. Entries with multiple vocal agents/layers **must** emit `agents`, and every attributed entry that uses `agents` **must** define exactly one `role: "main"` agent. A single-agent attributed/default layer may also use `agents` with that lone agent marked as `main`.
+
+When a cue includes `byteStart` / `byteEnd`, they are defined as 0-based inclusive offsets into the UTF-8 encoding of the final parent `cueLine.value`, with no normalization step.
 
 All new fields are gated behind `enhanced=true` — without it, the response is identical to version 1.
 

--- a/content/en/docs/Responses/cue.md
+++ b/content/en/docs/Responses/cue.md
@@ -13,11 +13,13 @@ description: >
 {
   "start": 2747,
   "end": 3018,
-  "value": "눈"
+  "value": "눈",
+  "byteStart": 0,
+  "byteEnd": 2
 }
 {{< /tab >}}
 {{< tab header="OpenSubsonic XML" lang="xml">}}
-<cue start="2747" end="3018">눈</cue>
+<cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
 Does not exist.
@@ -51,12 +53,12 @@ Does not exist.
 | ----------- | --------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `start`     | `integer` | **Yes** | **Yes** | Start time in milliseconds                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `end`       | `integer` | No      | **Yes** | End time in milliseconds. Within a [`cueLine`](../cueline), `end` **must** be either present on **all** cues or **none**. When the source provides partial end times, servers **must** fill missing values (e.g., using the next cue's `start`, or the cueLine's `end` for the final cue). When no cues have end times (e.g., Enhanced LRC with start-only timing), `end` is omitted from all cues. This is a documented contract rule; the OpenAPI schema does not enforce the all-or-none shape structurally |
-| `byteStart` | `integer` | No      | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue begins                                                                                                                                                                                                                                                                                                                                                                            |
-| `byteEnd`   | `integer` | No      | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue ends                                                                                                                                                                                                                                                                                                                                                                              |
+| `byteStart` | `integer` | **Yes** | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue begins                                                                                                                                                                                                                                                                                                                                                                            |
+| `byteEnd`   | `integer` | **Yes** | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue ends                                                                                                                                                                                                                                                                                                                                                                              |
 | `value`     | `string`  | **Yes** | **Yes** | The text of this word or syllable                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 
 {{< alert color="primary" title="byteStart / byteEnd behavior" >}}
-`byteStart` and `byteEnd` are an all-or-none pair on a cue. When present, both **must** be present, the parent `cueLine` **must** include `value`, the offsets are calculated against the final UTF-8 encoding of that `cueLine.value` with no normalization step, and `byteStart` **must** be less than or equal to `byteEnd`. This is a documented contract rule; the OpenAPI schema does not enforce the pairing or cross-field consistency structurally.
+Every cue **must** include `byteStart` and `byteEnd`. The parent `cueLine` **must** include `value`, the offsets are calculated against the final UTF-8 encoding of that `cueLine.value` with no normalization step, and `byteStart` **must** be less than or equal to `byteEnd`. The OpenAPI schema enforces the presence of the fields, but not the cross-field ordering constraint structurally.
 {{< /alert >}}
 
 {{< alert color="warning" title="OpenSubsonic" >}}

--- a/content/en/docs/Responses/cue.md
+++ b/content/en/docs/Responses/cue.md
@@ -24,11 +24,40 @@ Does not exist.
 {{< /tab >}}
 {{< /tabpane >}}
 
-| Field   | Type      | Req.    | OpenS.  | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| ------- | --------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `start` | `integer` | **Yes** | **Yes** | Start time in milliseconds                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `end`   | `integer` | No      | **Yes** | End time in milliseconds. Within a [`cueLine`](../cueline), `end` **must** be either present on **all** cues or **none**. When the source provides partial end times, servers **must** fill missing values (e.g., using the next cue's `start`, or the cueLine's `end` for the final cue). When no cues have end times (e.g., Enhanced LRC with start-only timing), `end` is omitted from all cues. This is a documented contract rule; the OpenAPI schema does not enforce the all-or-none shape structurally |
-| `value` | `string`  | **Yes** | **Yes** | The text of this word or syllable                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+##### Example with byte offsets
+
+When untimed text appears between timed cues, `byteStart` and `byteEnd` disambiguate repeated tokens by pointing at the exact substring within the parent `cueLine.value`. For example, within `cueLine.value = "Oh love love me tonight"`, the timed second `love` uses `byteStart = 8` and `byteEnd = 11`:
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
+{
+  "start": 900,
+  "end": 1300,
+  "value": "love",
+  "byteStart": 8,
+  "byteEnd": 11
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
+<cue start="900" end="1300" byteStart="8" byteEnd="11">love</cue>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+| Field       | Type      | Req.    | OpenS.  | Details                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------- | --------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `start`     | `integer` | **Yes** | **Yes** | Start time in milliseconds                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `end`       | `integer` | No      | **Yes** | End time in milliseconds. Within a [`cueLine`](../cueline), `end` **must** be either present on **all** cues or **none**. When the source provides partial end times, servers **must** fill missing values (e.g., using the next cue's `start`, or the cueLine's `end` for the final cue). When no cues have end times (e.g., Enhanced LRC with start-only timing), `end` is omitted from all cues. This is a documented contract rule; the OpenAPI schema does not enforce the all-or-none shape structurally |
+| `byteStart` | `integer` | No      | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue begins                                                                                                                                                                                                                                                                                                                                                                            |
+| `byteEnd`   | `integer` | No      | **Yes** | Zero-based inclusive UTF-8 byte offset into the parent [`cueLine.value`](../cueline) where this cue ends                                                                                                                                                                                                                                                                                                                                                                              |
+| `value`     | `string`  | **Yes** | **Yes** | The text of this word or syllable                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+
+{{< alert color="primary" title="byteStart / byteEnd behavior" >}}
+`byteStart` and `byteEnd` are an all-or-none pair on a cue. When present, both **must** be present, the parent `cueLine` **must** include `value`, the offsets are calculated against the final UTF-8 encoding of that `cueLine.value` with no normalization step, and `byteStart` **must** be less than or equal to `byteEnd`. This is a documented contract rule; the OpenAPI schema does not enforce the pairing or cross-field consistency structurally.
+{{< /alert >}}
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type added in extension [`songLyrics`](../../extensions/songlyrics) version 2.

--- a/content/en/docs/Responses/cueLine.md
+++ b/content/en/docs/Responses/cueLine.md
@@ -16,25 +16,25 @@ description: >
   "end": 6214,
   "value": "눈을 뜬 순간",
   "cue": [
-    { "start": 2747, "end": 3018, "value": "눈" },
-    { "start": 3018, "end": 3179, "value": "을" },
-    { "start": 3179, "end": 3582, "value": " " },
-    { "start": 3582, "end": 4100, "value": "뜬" },
-    { "start": 4100, "end": 4500, "value": " " },
-    { "start": 4500, "end": 5200, "value": "순" },
-    { "start": 5200, "end": 6214, "value": "간" }
+    { "start": 2747, "end": 3018, "value": "눈", "byteStart": 0, "byteEnd": 2 },
+    { "start": 3018, "end": 3179, "value": "을", "byteStart": 3, "byteEnd": 5 },
+    { "start": 3179, "end": 3582, "value": " ", "byteStart": 6, "byteEnd": 6 },
+    { "start": 3582, "end": 4100, "value": "뜬", "byteStart": 7, "byteEnd": 9 },
+    { "start": 4100, "end": 4500, "value": " ", "byteStart": 10, "byteEnd": 10 },
+    { "start": 4500, "end": 5200, "value": "순", "byteStart": 11, "byteEnd": 13 },
+    { "start": 5200, "end": 6214, "value": "간", "byteStart": 14, "byteEnd": 16 }
   ]
 }
 {{< /tab >}}
 {{< tab header="OpenSubsonic XML" lang="xml">}}
 <cueLine index="0" start="2747" end="6214" value="눈을 뜬 순간">
-  <cue start="2747" end="3018">눈</cue>
-  <cue start="3018" end="3179">을</cue>
-  <cue start="3179" end="3582"> </cue>
-  <cue start="3582" end="4100">뜬</cue>
-  <cue start="4100" end="4500"> </cue>
-  <cue start="4500" end="5200">순</cue>
-  <cue start="5200" end="6214">간</cue>
+  <cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
+  <cue start="3018" end="3179" byteStart="3" byteEnd="5">을</cue>
+  <cue start="3179" end="3582" byteStart="6" byteEnd="6"> </cue>
+  <cue start="3582" end="4100" byteStart="7" byteEnd="9">뜬</cue>
+  <cue start="4100" end="4500" byteStart="10" byteEnd="10"> </cue>
+  <cue start="4500" end="5200" byteStart="11" byteEnd="13">순</cue>
+  <cue start="5200" end="6214" byteStart="14" byteEnd="16">간</cue>
 </cueLine>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -54,17 +54,17 @@ Does not exist.
   "value": "You and I",
   "agentId": "lead",
   "cue": [
-    { "start": 1000, "end": 1800, "value": "You " },
-    { "start": 1800, "end": 2400, "value": "and " },
-    { "start": 2400, "end": 3200, "value": "I" }
+    { "start": 1000, "end": 1800, "value": "You ", "byteStart": 0, "byteEnd": 3 },
+    { "start": 1800, "end": 2400, "value": "and ", "byteStart": 4, "byteEnd": 7 },
+    { "start": 2400, "end": 3200, "value": "I", "byteStart": 8, "byteEnd": 8 }
   ]
 }
 {{< /tab >}}
 {{< tab header="OpenSubsonic XML" lang="xml">}}
 <cueLine index="0" start="1000" end="4000" value="You and I" agentId="lead">
-  <cue start="1000" end="1800">You </cue>
-  <cue start="1800" end="2400">and </cue>
-  <cue start="2400" end="3200">I</cue>
+  <cue start="1000" end="1800" byteStart="0" byteEnd="3">You </cue>
+  <cue start="1800" end="2400" byteStart="4" byteEnd="7">and </cue>
+  <cue start="2400" end="3200" byteStart="8" byteEnd="8">I</cue>
 </cueLine>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -110,9 +110,9 @@ Does not exist.
 | `index`   | `integer`                | **Yes** | **Yes** | Zero-based index into the parent `line` array this cueLine corresponds to                                                                                                                                                                                                                                                                                    |
 | `start`   | `integer`                | No      | **Yes** | Start time in milliseconds (may differ from the parent line if cues are more precise)                                                                                                                                                                                                                                                                        |
 | `end`     | `integer`                | No      | **Yes** | End time in milliseconds                                                                                                                                                                                                                                                                                                                                     |
-| `value`   | `string`                 | No      | **Yes** | Full text of the line (for validation/fallback). If any nested [`cue`](../cue) includes `byteStart` / `byteEnd`, `value` **must** be present and **must** match the exact final string used to compute those UTF-8 byte offsets                                                                                                                                                                                      |
+| `value`   | `string`                 | **Yes** | **Yes** | Full text of the line. Required because every nested [`cue`](../cue) defines `byteStart` / `byteEnd` against this exact final UTF-8 string                                                                                                                                                                                                                                                                                                                                       |
 | `agentId` | `string`                 | No      | **Yes** | Opaque identifier referencing an [`agent`](../agent) in the same [`structuredLyrics`](../structuredlyrics) entry. If the parent `structuredLyrics` entry includes `agents`, every cueLine in that entry **must** include `agentId`, and the value **must** match exactly one `agents[].id` in that entry. If the parent entry does not include `agents`, cueLines **must not** include `agentId`. When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first |
-| `cue`     | Array of [`cue`](../cue) | **Yes** | **Yes** | Ordered list of word/syllable cues, optionally annotated with `byteStart` / `byteEnd` offsets into `value`                                                                                                                                                                                                                                                 |
+| `cue`     | Array of [`cue`](../cue) | **Yes** | **Yes** | Ordered list of word/syllable cues. Every cue **must** include `byteStart` / `byteEnd` offsets into `value`                                                                                                                                                                                                                                                                                                                       |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type added in extension [`songLyrics`](../../extensions/songlyrics) version 2.

--- a/content/en/docs/Responses/cueLine.md
+++ b/content/en/docs/Responses/cueLine.md
@@ -72,14 +72,47 @@ Does not exist.
 {{< /tab >}}
 {{< /tabpane >}}
 
-| Field     | Type                          | Req.    | OpenS.  | Details                                                                                                                                                                                                                                                                                                                                                      |
-| --------- | ----------------------------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `index`   | `integer`                     | **Yes** | **Yes** | Zero-based index into the parent `line` array this cueLine corresponds to                                                                                                                                                                                                                                                                                    |
-| `start`   | `integer`                     | No      | **Yes** | Start time in milliseconds (may differ from the parent line if cues are more precise)                                                                                                                                                                                                                                                                        |
-| `end`     | `integer`                     | No      | **Yes** | End time in milliseconds                                                                                                                                                                                                                                                                                                                                     |
-| `value`   | `string`                      | No      | **Yes** | Full text of the line (for validation/fallback)                                                                                                                                                                                                                                                                                                              |
-| `agentId` | `string`                      | No      | **Yes** | Opaque identifier referencing an [`agent`](../agent) in the same [`structuredLyrics`](../structuredlyrics) entry. If the parent `structuredLyrics` entry includes `agents`, every cueLine in that entry **must** include `agentId`, and the value **must** match exactly one `agents[].id` in that entry. If the parent entry does not include `agents`, cueLines **must not** include `agentId`. When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first |
-| `cue`     | Array of [`cue`](../cue)      | **Yes** | **Yes** | Ordered list of word/syllable cues                                                                                                                                                                                                                                                                                                                           |
+##### Example with ambiguous repeated text
+
+When untimed text appears between timed cues, `cueLine.value` plus cue `byteStart` / `byteEnd` offsets identifies the exact occurrence of a repeated token:
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
+{
+  "index": 0,
+  "start": 0,
+  "end": 2400,
+  "value": "Oh love love me tonight",
+  "cue": [
+    { "start": 0, "end": 300, "value": "Oh", "byteStart": 0, "byteEnd": 1 },
+    { "start": 900, "end": 1300, "value": "love", "byteStart": 8, "byteEnd": 11 },
+    { "start": 1300, "end": 1600, "value": "me", "byteStart": 13, "byteEnd": 14 },
+    { "start": 1600, "end": 2400, "value": "tonight", "byteStart": 16, "byteEnd": 22 }
+  ]
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
+<cueLine index="0" start="0" end="2400" value="Oh love love me tonight">
+  <cue start="0" end="300" byteStart="0" byteEnd="1">Oh</cue>
+  <cue start="900" end="1300" byteStart="8" byteEnd="11">love</cue>
+  <cue start="1300" end="1600" byteStart="13" byteEnd="14">me</cue>
+  <cue start="1600" end="2400" byteStart="16" byteEnd="22">tonight</cue>
+</cueLine>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+| Field     | Type                     | Req.    | OpenS.  | Details                                                                                                                                                                                                                                                                                                                                                      |
+| --------- | ------------------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `index`   | `integer`                | **Yes** | **Yes** | Zero-based index into the parent `line` array this cueLine corresponds to                                                                                                                                                                                                                                                                                    |
+| `start`   | `integer`                | No      | **Yes** | Start time in milliseconds (may differ from the parent line if cues are more precise)                                                                                                                                                                                                                                                                        |
+| `end`     | `integer`                | No      | **Yes** | End time in milliseconds                                                                                                                                                                                                                                                                                                                                     |
+| `value`   | `string`                 | No      | **Yes** | Full text of the line (for validation/fallback). If any nested [`cue`](../cue) includes `byteStart` / `byteEnd`, `value` **must** be present and **must** match the exact final string used to compute those UTF-8 byte offsets                                                                                                                                                                                      |
+| `agentId` | `string`                 | No      | **Yes** | Opaque identifier referencing an [`agent`](../agent) in the same [`structuredLyrics`](../structuredlyrics) entry. If the parent `structuredLyrics` entry includes `agents`, every cueLine in that entry **must** include `agentId`, and the value **must** match exactly one `agents[].id` in that entry. If the parent entry does not include `agents`, cueLines **must not** include `agentId`. When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first |
+| `cue`     | Array of [`cue`](../cue) | **Yes** | **Yes** | Ordered list of word/syllable cues, optionally annotated with `byteStart` / `byteEnd` offsets into `value`                                                                                                                                                                                                                                                 |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type added in extension [`songLyrics`](../../extensions/songlyrics) version 2.

--- a/content/en/docs/Responses/structuredLyrics.md
+++ b/content/en/docs/Responses/structuredLyrics.md
@@ -48,9 +48,9 @@ Does not exist.
 
 ### Version 2 (enhanced — word/syllable-level with kind)
 
-When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, `cueLine` arrays with word/syllable-level timing, and optional `agents` arrays for reusable agent attribution.
+When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, `cueLine` arrays with word/syllable-level timing, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value` when repeated text would otherwise be ambiguous, and optional `agents` arrays for reusable agent attribution.
 
-Each `structuredLyrics` entry is self-contained. Clients should treat tracks with different `kind` values, including `main`, as independent layers rather than assuming 1:1 line or cue alignment between them. Agent identity is also scoped to a single `structuredLyrics` entry; `agents[].id` values have no meaning outside that entry.
+Each `structuredLyrics` entry is self-contained. Clients should treat tracks with different `kind` values, including `main`, as independent layers rather than assuming 1:1 line or cue alignment between them. Agent identity is also scoped to a single `structuredLyrics` entry; `agents[].id` values have no meaning outside that entry. When a cue uses `byteStart` / `byteEnd`, those offsets are always relative to the final `cueLine.value` string in the same entry.
 
 {{< tabpane persist=false >}}
 {{< tab header="**Example**:" disabled=true />}}

--- a/content/en/docs/Responses/structuredLyrics.md
+++ b/content/en/docs/Responses/structuredLyrics.md
@@ -48,7 +48,7 @@ Does not exist.
 
 ### Version 2 (enhanced — word/syllable-level with kind)
 
-When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, `cueLine` arrays with word/syllable-level timing, optional cue `byteStart` / `byteEnd` offsets into `cueLine.value` when repeated text would otherwise be ambiguous, and optional `agents` arrays for reusable agent attribution.
+When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, `cueLine` arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and optional `agents` arrays for reusable agent attribution.
 
 Each `structuredLyrics` entry is self-contained. Clients should treat tracks with different `kind` values, including `main`, as independent layers rather than assuming 1:1 line or cue alignment between them. Agent identity is also scoped to a single `structuredLyrics` entry; `agents[].id` values have no meaning outside that entry. When a cue uses `byteStart` / `byteEnd`, those offsets are always relative to the final `cueLine.value` string in the same entry.
 
@@ -70,13 +70,13 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
       "end": 6214,
       "value": "눈을 뜬 순간",
       "cue": [
-        { "start": 2747, "end": 3018, "value": "눈" },
-        { "start": 3018, "end": 3179, "value": "을" },
-        { "start": 3179, "end": 3582, "value": " " },
-        { "start": 3582, "end": 4100, "value": "뜬" },
-        { "start": 4100, "end": 4500, "value": " " },
-        { "start": 4500, "end": 5200, "value": "순" },
-        { "start": 5200, "end": 6214, "value": "간" }
+        { "start": 2747, "end": 3018, "value": "눈", "byteStart": 0, "byteEnd": 2 },
+        { "start": 3018, "end": 3179, "value": "을", "byteStart": 3, "byteEnd": 5 },
+        { "start": 3179, "end": 3582, "value": " ", "byteStart": 6, "byteEnd": 6 },
+        { "start": 3582, "end": 4100, "value": "뜬", "byteStart": 7, "byteEnd": 9 },
+        { "start": 4100, "end": 4500, "value": " ", "byteStart": 10, "byteEnd": 10 },
+        { "start": 4500, "end": 5200, "value": "순", "byteStart": 11, "byteEnd": 13 },
+        { "start": 5200, "end": 6214, "value": "간", "byteStart": 14, "byteEnd": 16 }
       ]
     },
     {
@@ -85,12 +85,12 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
       "end": 9000,
       "value": "모든 게 달라졌어",
       "cue": [
-        { "start": 6214, "end": 6800, "value": "모" },
-        { "start": 6800, "end": 7200, "value": "든" },
-        { "start": 7200, "end": 7600, "value": " " },
-        { "start": 7600, "end": 8000, "value": "게" },
-        { "start": 8000, "end": 8400, "value": " " },
-        { "start": 8400, "end": 9000, "value": "달라졌어" }
+        { "start": 6214, "end": 6800, "value": "모", "byteStart": 0, "byteEnd": 2 },
+        { "start": 6800, "end": 7200, "value": "든", "byteStart": 3, "byteEnd": 5 },
+        { "start": 7200, "end": 7600, "value": " ", "byteStart": 6, "byteEnd": 6 },
+        { "start": 7600, "end": 8000, "value": "게", "byteStart": 7, "byteEnd": 9 },
+        { "start": 8000, "end": 8400, "value": " ", "byteStart": 10, "byteEnd": 10 },
+        { "start": 8400, "end": 9000, "value": "달라졌어", "byteStart": 11, "byteEnd": 22 }
       ]
     }
   ]
@@ -101,21 +101,21 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
   <line start="2747">눈을 뜬 순간</line>
   <line start="6214">모든 게 달라졌어</line>
   <cueLine index="0" start="2747" end="6214" value="눈을 뜬 순간">
-    <cue start="2747" end="3018">눈</cue>
-    <cue start="3018" end="3179">을</cue>
-    <cue start="3179" end="3582"> </cue>
-    <cue start="3582" end="4100">뜬</cue>
-    <cue start="4100" end="4500"> </cue>
-    <cue start="4500" end="5200">순</cue>
-    <cue start="5200" end="6214">간</cue>
+    <cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
+    <cue start="3018" end="3179" byteStart="3" byteEnd="5">을</cue>
+    <cue start="3179" end="3582" byteStart="6" byteEnd="6"> </cue>
+    <cue start="3582" end="4100" byteStart="7" byteEnd="9">뜬</cue>
+    <cue start="4100" end="4500" byteStart="10" byteEnd="10"> </cue>
+    <cue start="4500" end="5200" byteStart="11" byteEnd="13">순</cue>
+    <cue start="5200" end="6214" byteStart="14" byteEnd="16">간</cue>
   </cueLine>
   <cueLine index="1" start="6214" end="9000" value="모든 게 달라졌어">
-    <cue start="6214" end="6800">모</cue>
-    <cue start="6800" end="7200">든</cue>
-    <cue start="7200" end="7600"> </cue>
-    <cue start="7600" end="8000">게</cue>
-    <cue start="8000" end="8400"> </cue>
-    <cue start="8400" end="9000">달라졌어</cue>
+    <cue start="6214" end="6800" byteStart="0" byteEnd="2">모</cue>
+    <cue start="6800" end="7200" byteStart="3" byteEnd="5">든</cue>
+    <cue start="7200" end="7600" byteStart="6" byteEnd="6"> </cue>
+    <cue start="7600" end="8000" byteStart="7" byteEnd="9">게</cue>
+    <cue start="8000" end="8400" byteStart="10" byteEnd="10"> </cue>
+    <cue start="8400" end="9000" byteStart="11" byteEnd="22">달라졌어</cue>
   </cueLine>
 </structuredLyrics>
 {{< /tab >}}
@@ -153,9 +153,9 @@ When a source distinguishes one or more explicit vocal agents within the same `s
       "end": 4000,
       "value": "You and I",
       "cue": [
-        { "start": 1000, "end": 1800, "value": "You " },
-        { "start": 1800, "end": 2400, "value": "and " },
-        { "start": 2400, "end": 3200, "value": "I" }
+        { "start": 1000, "end": 1800, "value": "You ", "byteStart": 0, "byteEnd": 3 },
+        { "start": 1800, "end": 2400, "value": "and ", "byteStart": 4, "byteEnd": 7 },
+        { "start": 2400, "end": 3200, "value": "I", "byteStart": 8, "byteEnd": 8 }
       ]
     },
     {
@@ -165,10 +165,10 @@ When a source distinguishes one or more explicit vocal agents within the same `s
       "end": 7000,
       "value": "Under this sky",
       "cue": [
-        { "start": 4000, "end": 4800, "value": "Un" },
-        { "start": 4800, "end": 5400, "value": "der " },
-        { "start": 5400, "end": 5900, "value": "this " },
-        { "start": 5900, "end": 7000, "value": "sky" }
+        { "start": 4000, "end": 4800, "value": "Un", "byteStart": 0, "byteEnd": 1 },
+        { "start": 4800, "end": 5400, "value": "der ", "byteStart": 2, "byteEnd": 5 },
+        { "start": 5400, "end": 5900, "value": "this ", "byteStart": 6, "byteEnd": 10 },
+        { "start": 5900, "end": 7000, "value": "sky", "byteStart": 11, "byteEnd": 13 }
       ]
     },
     {
@@ -178,10 +178,10 @@ When a source distinguishes one or more explicit vocal agents within the same `s
       "end": 10000,
       "value": "Together tonight",
       "cue": [
-        { "start": 7000, "end": 8000, "value": "To" },
-        { "start": 8000, "end": 8800, "value": "ge" },
-        { "start": 8800, "end": 9200, "value": "ther " },
-        { "start": 9200, "end": 10000, "value": "tonight" }
+        { "start": 7000, "end": 8000, "value": "To", "byteStart": 0, "byteEnd": 1 },
+        { "start": 8000, "end": 8800, "value": "ge", "byteStart": 2, "byteEnd": 3 },
+        { "start": 8800, "end": 9200, "value": "ther ", "byteStart": 4, "byteEnd": 8 },
+        { "start": 9200, "end": 10000, "value": "tonight", "byteStart": 9, "byteEnd": 15 }
       ]
     }
   ]
@@ -196,21 +196,21 @@ When a source distinguishes one or more explicit vocal agents within the same `s
   <agent id="guest" role="voice" name="Jin" />
   <agent id="choir" role="group" name="All" />
   <cueLine index="0" agentId="lead" start="1000" end="4000" value="You and I">
-    <cue start="1000" end="1800">You </cue>
-    <cue start="1800" end="2400">and </cue>
-    <cue start="2400" end="3200">I</cue>
+    <cue start="1000" end="1800" byteStart="0" byteEnd="3">You </cue>
+    <cue start="1800" end="2400" byteStart="4" byteEnd="7">and </cue>
+    <cue start="2400" end="3200" byteStart="8" byteEnd="8">I</cue>
   </cueLine>
   <cueLine index="1" agentId="guest" start="4000" end="7000" value="Under this sky">
-    <cue start="4000" end="4800">Un</cue>
-    <cue start="4800" end="5400">der </cue>
-    <cue start="5400" end="5900">this </cue>
-    <cue start="5900" end="7000">sky</cue>
+    <cue start="4000" end="4800" byteStart="0" byteEnd="1">Un</cue>
+    <cue start="4800" end="5400" byteStart="2" byteEnd="5">der </cue>
+    <cue start="5400" end="5900" byteStart="6" byteEnd="10">this </cue>
+    <cue start="5900" end="7000" byteStart="11" byteEnd="13">sky</cue>
   </cueLine>
   <cueLine index="2" agentId="choir" start="7000" end="10000" value="Together tonight">
-    <cue start="7000" end="8000">To</cue>
-    <cue start="8000" end="8800">ge</cue>
-    <cue start="8800" end="9200">ther </cue>
-    <cue start="9200" end="10000">tonight</cue>
+    <cue start="7000" end="8000" byteStart="0" byteEnd="1">To</cue>
+    <cue start="8000" end="8800" byteStart="2" byteEnd="3">ge</cue>
+    <cue start="8800" end="9200" byteStart="4" byteEnd="8">ther </cue>
+    <cue start="9200" end="10000" byteStart="9" byteEnd="15">tonight</cue>
   </cueLine>
 </structuredLyrics>
 {{< /tab >}}
@@ -237,20 +237,22 @@ The same song with `kind: "pronunciation"` — note how cue counts differ from t
       "index": 0,
       "start": 2747,
       "end": 6214,
+      "value": "nuneul tteun sungan",
       "cue": [
-        { "start": 2747, "end": 3179, "value": "nuneul" },
-        { "start": 3582, "end": 4100, "value": "tteun" },
-        { "start": 4500, "end": 6214, "value": "sungan" }
+        { "start": 2747, "end": 3179, "value": "nuneul", "byteStart": 0, "byteEnd": 5 },
+        { "start": 3582, "end": 4100, "value": "tteun", "byteStart": 7, "byteEnd": 11 },
+        { "start": 4500, "end": 6214, "value": "sungan", "byteStart": 13, "byteEnd": 18 }
       ]
     },
     {
       "index": 1,
       "start": 6214,
       "end": 9000,
+      "value": "modeun ge dallajyeosseo",
       "cue": [
-        { "start": 6214, "end": 7200, "value": "modeun" },
-        { "start": 7600, "end": 8000, "value": "ge" },
-        { "start": 8400, "end": 9000, "value": "dallajyeosseo" }
+        { "start": 6214, "end": 7200, "value": "modeun", "byteStart": 0, "byteEnd": 5 },
+        { "start": 7600, "end": 8000, "value": "ge", "byteStart": 7, "byteEnd": 8 },
+        { "start": 8400, "end": 9000, "value": "dallajyeosseo", "byteStart": 10, "byteEnd": 22 }
       ]
     }
   ]
@@ -260,15 +262,15 @@ The same song with `kind: "pronunciation"` — note how cue counts differ from t
 <structuredLyrics kind="pronunciation" lang="ko-Latn" synced="true">
   <line start="2747">nuneul tteun sungan</line>
   <line start="6214">modeun ge dallajyeosseo</line>
-  <cueLine index="0" start="2747" end="6214">
-    <cue start="2747" end="3179">nuneul</cue>
-    <cue start="3582" end="4100">tteun</cue>
-    <cue start="4500" end="6214">sungan</cue>
+  <cueLine index="0" start="2747" end="6214" value="nuneul tteun sungan">
+    <cue start="2747" end="3179" byteStart="0" byteEnd="5">nuneul</cue>
+    <cue start="3582" end="4100" byteStart="7" byteEnd="11">tteun</cue>
+    <cue start="4500" end="6214" byteStart="13" byteEnd="18">sungan</cue>
   </cueLine>
-  <cueLine index="1" start="6214" end="9000">
-    <cue start="6214" end="7200">modeun</cue>
-    <cue start="7600" end="8000">ge</cue>
-    <cue start="8400" end="9000">dallajyeosseo</cue>
+  <cueLine index="1" start="6214" end="9000" value="modeun ge dallajyeosseo">
+    <cue start="6214" end="7200" byteStart="0" byteEnd="5">modeun</cue>
+    <cue start="7600" end="8000" byteStart="7" byteEnd="8">ge</cue>
+    <cue start="8400" end="9000" byteStart="10" byteEnd="22">dallajyeosseo</cue>
   </cueLine>
 </structuredLyrics>
 {{< /tab >}}
@@ -289,7 +291,7 @@ Does not exist.
 | `offset`        | `number`                             | No      | **Yes** | The offset to apply to all lyrics, in milliseconds. Positive means lyrics appear sooner, negative means later. If not included, the offset **must** be assumed to be 0                                                                                                                                                                         |
 | `kind`          | `string`                             | No      | **Yes** | The primary lyric-layer classification for this `structuredLyrics` entry. One of: `main` (primary vocals for this entry, default if omitted), `translation` (a translation of another lyric layer into another language), `pronunciation` (a phonetic/romanized rendering, e.g. romaji for Japanese, pinyin for Chinese). Tracks are independent across `kind` values; clients should not assume 1:1 line or cue alignment between entries. Only returned when `enhanced=true`. Added in [`songLyrics`](../../extensions/songlyrics) version 2 |
 | `agents`        | Array of [`agent`](../agent)         | No      | **Yes** | Reusable per-track attribution metadata for `cueLine` entries. When present, **must** contain at least one entry, and each `agents[].id` **must** be unique within this `structuredLyrics` entry. `agents` are optional for simple unattributed single-layer lyrics. When a `structuredLyrics` entry represents multiple vocal agents/layers, it **must** include `agents`; a single-agent attributed/default entry may also include `agents`, and if it does, exactly one agent **must** use `role: "main"`. `agents` should not be emitted without `cueLine` data |
-| `cueLine`       | Array of [`cueLine`](../cueline)     | No      | **Yes** | Word/syllable-level timing data. Each cueLine corresponds to a `line` by its `index` field. If `agents` is present, every cueLine in the entry **must** include `agentId`; if `agents` is absent, cueLines **must not** include `agentId`. Only returned when `enhanced=true` and `synced` is `true`. Added in [`songLyrics`](../../extensions/songlyrics) version 2 |
+| `cueLine`       | Array of [`cueLine`](../cueline)     | No      | **Yes** | Word/syllable-level timing data. Each cueLine corresponds to a `line` by its `index` field. Every cueLine **must** include `value`, and every nested cue **must** include `byteStart` / `byteEnd` offsets into that exact string. If `agents` is present, every cueLine in the entry **must** include `agentId`; if `agents` is absent, cueLines **must not** include `agentId`. Only returned when `enhanced=true` and `synced` is `true`. Added in [`songLyrics`](../../extensions/songlyrics) version 2 |
 
 If `agents` is present, each `cueLine.agentId` **must** resolve to exactly one `agents[].id` in the same `structuredLyrics` entry.
 

--- a/openapi/endpoints/getLyricsBySongId.json
+++ b/openapi/endpoints/getLyricsBySongId.json
@@ -20,7 +20,7 @@
             {
                 "name": "enhanced",
                 "in": "query",
-                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, optional cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data.",
+                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, required cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data.",
                 "required": false,
                 "schema": {
                     "type": "boolean",
@@ -70,7 +70,7 @@
                             "enhanced": {
                                 "type": "boolean",
                                 "default": false,
-                                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, optional cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data."
+                                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, required cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data."
                             }
                         },
                         "required": [

--- a/openapi/endpoints/getLyricsBySongId.json
+++ b/openapi/endpoints/getLyricsBySongId.json
@@ -20,7 +20,7 @@
             {
                 "name": "enhanced",
                 "in": "query",
-                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data.",
+                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, optional cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data.",
                 "required": false,
                 "schema": {
                     "type": "boolean",
@@ -70,7 +70,7 @@
                             "enhanced": {
                                 "type": "boolean",
                                 "default": false,
-                                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data."
+                                "description": "When true, the response includes cueLine arrays with word/syllable-level timing data, optional cue byteStart and byteEnd offsets into cueLine.value, and non-main kind tracks (translations, pronunciations). When false or omitted, only kind=main entries are returned with no cueLine data."
                             }
                         },
                         "required": [

--- a/openapi/schemas/Cue.json
+++ b/openapi/schemas/Cue.json
@@ -17,12 +17,12 @@
     "byteStart": {
       "type": "integer",
       "minimum": 0,
-      "description": "Zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue begins. If present, byteEnd must also be present, the parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step. This is a documented contract rule; the schema does not enforce the pairing or cross-field consistency structurally"
+      "description": "Required zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue begins. The parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step"
     },
     "byteEnd": {
       "type": "integer",
       "minimum": 0,
-      "description": "Zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue ends. If present, byteStart must also be present, byteStart must be less than or equal to byteEnd, the parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step. This is a documented contract rule; the schema does not enforce the pairing or cross-field consistency structurally"
+      "description": "Required zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue ends. byteStart must be less than or equal to byteEnd, the parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step. This schema does not enforce the cross-field ordering constraint structurally"
     },
     "value": {
       "type": "string",
@@ -31,6 +31,8 @@
   },
   "required": [
     "start",
+    "byteStart",
+    "byteEnd",
     "value"
   ]
 }

--- a/openapi/schemas/Cue.json
+++ b/openapi/schemas/Cue.json
@@ -14,6 +14,16 @@
       "type": "integer",
       "description": "End time in milliseconds. Within a cueLine, end must be either present on all cues or none. When the source provides partial end times, servers must fill missing values (e.g., using the next cue's start, or the cueLine's end for the final cue). When no cues have end times (e.g., Enhanced LRC with start-only timing), end is omitted from all cues. This is a documented contract rule; this schema does not enforce the all-or-none shape structurally"
     },
+    "byteStart": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue begins. If present, byteEnd must also be present, the parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step. This is a documented contract rule; the schema does not enforce the pairing or cross-field consistency structurally"
+    },
+    "byteEnd": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Zero-based inclusive UTF-8 byte offset into the parent cueLine.value where this cue ends. If present, byteStart must also be present, byteStart must be less than or equal to byteEnd, the parent cueLine must include value, and the offsets must be calculated against the final cueLine.value with no normalization step. This is a documented contract rule; the schema does not enforce the pairing or cross-field consistency structurally"
+    },
     "value": {
       "type": "string",
       "description": "The text of this word or syllable"

--- a/openapi/schemas/CueLine.json
+++ b/openapi/schemas/CueLine.json
@@ -20,7 +20,7 @@
     },
     "value": {
       "type": "string",
-      "description": "Full text of the line (for validation/fallback)"
+      "description": "Full text of the line (for validation/fallback). If any nested cue includes byteStart and byteEnd, value must be present and must match the exact final string used to compute those UTF-8 byte offsets"
     },
     "agentId": {
       "type": "string",
@@ -28,7 +28,7 @@
     },
     "cue": {
       "type": "array",
-      "description": "Ordered list of word/syllable cues",
+      "description": "Ordered list of word/syllable cues, optionally annotated with byteStart and byteEnd offsets into value",
       "items": {
         "$ref": "./Cue.json"
       }

--- a/openapi/schemas/CueLine.json
+++ b/openapi/schemas/CueLine.json
@@ -20,7 +20,7 @@
     },
     "value": {
       "type": "string",
-      "description": "Full text of the line (for validation/fallback). If any nested cue includes byteStart and byteEnd, value must be present and must match the exact final string used to compute those UTF-8 byte offsets"
+      "description": "Required full text of the line. Nested cue byteStart and byteEnd offsets are always calculated against this exact final UTF-8 string"
     },
     "agentId": {
       "type": "string",
@@ -28,7 +28,7 @@
     },
     "cue": {
       "type": "array",
-      "description": "Ordered list of word/syllable cues, optionally annotated with byteStart and byteEnd offsets into value",
+      "description": "Ordered list of word/syllable cues. Every cue includes required byteStart and byteEnd offsets into value",
       "items": {
         "$ref": "./Cue.json"
       }
@@ -36,6 +36,7 @@
   },
   "required": [
     "index",
+    "value",
     "cue"
   ]
 }

--- a/openapi/schemas/StructuredLyrics.json
+++ b/openapi/schemas/StructuredLyrics.json
@@ -52,7 +52,7 @@
         },
         "cueLine": {
             "type": "array",
-            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Cues may also include byteStart and byteEnd offsets into cueLine.value when repeated text would otherwise be ambiguous. Only returned when enhanced=true and synced is true",
+            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. Every cueLine includes value, and every cue includes byteStart and byteEnd offsets into that exact string. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Only returned when enhanced=true and synced is true",
             "items": {
                 "$ref": "./CueLine.json"
             }

--- a/openapi/schemas/StructuredLyrics.json
+++ b/openapi/schemas/StructuredLyrics.json
@@ -52,7 +52,7 @@
         },
         "cueLine": {
             "type": "array",
-            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Only returned when enhanced=true and synced is true",
+            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Cues may also include byteStart and byteEnd offsets into cueLine.value when repeated text would otherwise be ambiguous. Only returned when enhanced=true and synced is true",
             "items": {
                 "$ref": "./CueLine.json"
             }


### PR DESCRIPTION
## Summary

This follow-up amends the `songLyrics` v2 cue model to disambiguate repeated timed/untimed text within a `cueLine.value`.

It adds optional `byteStart` / `byteEnd` fields on `cue`, defined as 0-based inclusive UTF-8 byte offsets into the final parent `cueLine.value`, with no normalization step.

## Changes

- add `byteStart` / `byteEnd` to the `cue` docs and OpenAPI schema
- document them as an all-or-none pair
- document that they are only valid relative to `cueLine.value`
- document the invariant `byteStart <= byteEnd`
- propagate the contract text through `cueLine`, `structuredLyrics`, `songLyrics`, and `getLyricsBySongId`
