### PR TITLE
feat(extension): infiniteLibrary — scalable support for large and cloud-backed catalogs

### DIFF
--- a/content/en/docs/Endpoints/gettopsongs.md
+++ b/content/en/docs/Endpoints/gettopsongs.md
@@ -15,8 +15,17 @@ Returns top songs for the given artist, using data from [last.fm](http://last.fm
 
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
-| `artist` | **Yes** |  |   | The artist name. |
+| `artist` | **Yes*** |  |   | The artist name. |
+| `artistId` | No | **Yes** |   | The artist ID. If provided, takes precedence over the `artist` string. |
 | `count` | No  | |  50  | Max number of songs to return. |
+
+{{< alert color="warning" title="OpenSubsonic" >}}
+**`infiniteLibrary` extension (version 1):**
+
+The `artist` parameter requires the server to perform a string-based lookup which can be ambiguous when multiple artists share similar names. Servers that support the [`infiniteLibrary`](../../extensions/infinitelibrary/) extension SHOULD accept the `artistId` parameter and use it for a direct, deterministic lookup.
+
+When `artistId` is provided, the `artist` parameter becomes optional. Servers MUST return an error if neither `artist` nor `artistId` is provided.
+{{< /alert >}}
 
 ### Example
 

--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -27,9 +27,16 @@ Music is organized according to ID3 tags.
 | `songCount` | No |   | 20  | Maximum number of songs to return. |
 | `songOffset` | No |   | 0   | Search result offset for songs. Used for paging. |
 | `musicFolderId` | No |   |     | (Since [1.12.0](../../subsonic-versions)) Only return results from music folder with the given ID. See `getMusicFolders`. |
+| `type` | No | **Yes** |  | Comma-separated list of result types to include: `artist`, `album`, `song`. If omitted, all types are returned. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 Servers must support an **empty query** and return all the data to allow clients to properly access all the media information for offline sync.
+
+**`infiniteLibrary` extension (version 1):**
+
+- Servers that support very large catalogs MAY return error code `71` for empty queries when the library exceeds a practical sync threshold.
+- The `type` parameter allows clients to explicitly request only the result types they need. When specified, the server SHOULD skip computation for excluded types entirely (not just omit them from the response). This is semantically stronger than setting a count to `0`, which has undefined behavior across implementations.
+- When a count parameter is explicitly set to `0` (e.g., `artistCount=0`), servers MUST NOT return results of that type, and SHOULD NOT perform the underlying search for that type.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Endpoints/stream.md
+++ b/content/en/docs/Endpoints/stream.md
@@ -26,6 +26,7 @@ Streams a given media file.
 | `size` | No  |   |   | (Since [1.6.0](../../subsonic-versions)) Only applicable to video streaming. Requested video size specified as WxH, for instance "640x480". |
 | `estimateContentLength` | No |  | false | (Since [1.8.0](../../subsonic-versions)). If set to "true", the *Content-Length* HTTP header will be set to an estimated value for transcoded or downsampled media. |
 | `converted` | No  | | false | (Since [1.14.0](../../subsonic-versions)) Only applicable to video streaming. Servers can optimize videos for streaming by converting them to MP4. If a conversion exists for the video in question, then setting this parameter to "true" will cause the converted video to be returned instead of the original. |
+| `streamMode` | No | **Yes** | `binary` | `binary`: current behavior (raw audio bytes). `redirect`: server returns HTTP 302 to the audio source URL. `manifest`: server returns an HLS/DASH manifest if the source supports adaptive streaming. `infiniteLibrary` extension (version 2). |
 
 ### Example
 
@@ -40,4 +41,12 @@ OpenSubsonic servers **must not** count access to this endpoint as a play and in
 
 If the server support the [`Transcode Offset`](../../extensions/transcodeoffset/) extension, then it must accept the `timeOffset` parameter for music too.
 
+**`infiniteLibrary` extension (version 2):**
+
+The `streamMode` parameter allows clients to opt into more efficient streaming modes:
+
+- `redirect`: The server responds with HTTP 302 pointing to the actual audio file URL. Suitable for native clients that can follow redirects and handle direct streams. This eliminates server-side proxying overhead entirely.
+- `manifest`: The server responds with an HLS (`.m3u8`) or DASH (`.mpd`) manifest. Suitable for clients that support adaptive bitrate streaming. The response Content-Type will be `application/vnd.apple.mpegurl` or `application/dash+xml`.
+
+If the server cannot fulfill the requested `streamMode`, it MUST fall back to `binary` mode silently.
 {{< /alert >}}

--- a/content/en/docs/Extensions/infiniteLibrary.md
+++ b/content/en/docs/Extensions/infiniteLibrary.md
@@ -1,0 +1,126 @@
+---
+title: "Infinite Library"
+linkTitle: "Infinite Library"
+OpenSubsonic:
+- Extension
+description: >
+  Enables scalable, deterministic behavior for servers backed by very large or cloud-hosted music catalogs.
+---
+
+**OpenSubsonic version**: [1](../../opensubsonic-versions)
+
+**OpenSubsonic extension name**: `infiniteLibrary` (As returned by [`getOpenSubsonicExtensions`](../../endpoints/getopensubsonicextensions))
+
+This extension addresses scalability and determinism challenges that arise when an OpenSubsonic server acts as a bridge to a very large music catalog (e.g., cloud-hosted services with millions of items, or large self-hosted collections with ambiguous metadata).
+
+The core principle is: **prefer IDs over strings, and allow clients to request only what they need.**
+
+## Motivation
+
+Several existing endpoints were designed with the assumption that the server has a small, fully-indexed local library. When libraries grow to millions of items, or when the server proxies an external catalog:
+
+- String-based artist lookups become ambiguous (e.g., multiple artists named "Savant")
+- Returning all three result types (artists, albums, songs) for every search wastes resources when the client only needs one
+- Clients cannot distinguish exact matches from fuzzy ones
+- Cover art proxying creates unnecessary load when direct URLs are available
+
+## Version 1
+
+### `getTopSongs` — ID-based artist resolution
+
+The `getTopSongs` endpoint currently requires an `artist` string parameter. This extension adds an optional `artistId` parameter that, when provided, takes precedence over the `artist` string and eliminates ambiguity.
+
+**New parameter:**
+
+| Parameter | Req. | Default | Comment |
+| --- | --- | --- | --- |
+| `artistId` | No |  | The artist ID. If provided, the server MUST use this instead of the `artist` string for lookups. |
+
+When `artistId` is provided, the `artist` parameter becomes optional. Servers MUST return an error if neither `artist` nor `artistId` is provided.
+
+### `search3` — Type filtering and match precision
+
+This extension adds optional parameters to `search3` that allow clients to express their intent more precisely:
+
+**New parameters:**
+
+| Parameter | Req. | Default | Comment |
+| --- | --- | --- | --- |
+| `type` | No |  | Comma-separated list of result types to include: `artist`, `album`, `song`. If omitted, all types are returned (current behavior). |
+
+When `type` is specified, the server SHOULD skip computation for excluded types entirely, not just omit them from the response. For example, `type=album` means the server does not need to search for artists or songs at all.
+
+This is semantically different from setting `artistCount=0&songCount=0`, which currently has undefined behavior — some servers still perform the search and discard results, others may ignore zero counts entirely.
+
+### `AlbumID3` and `Child` — Embedded cover art URLs
+
+This extension adds an optional `coverArtUrl` field to `AlbumID3` and `Child` responses:
+
+| Field | Type | Req. | Details |
+| --- | --- | --- | --- |
+| `coverArtUrl` | `string` | No | A direct URL to the cover art image. If present, clients SHOULD prefer this over calling `getCoverArt`. |
+
+This reduces the N+1 problem where displaying 25 search results requires 25 additional `getCoverArt` calls. Servers that host artwork on CDNs or proxy external catalogs can embed the URL directly.
+
+### Error code 71 — Library too large
+
+When a client sends an empty `query` to `search3` (which OpenSubsonic requires servers to support for offline sync), servers with very large catalogs MAY return error code `71` with a message indicating that full library enumeration is not supported.
+
+| Code | Description |
+| --- | --- |
+| 71 | The requested operation would return too many results. The client should refine the query. |
+
+### `searchResult3` — Total count metadata
+
+This extension adds optional count fields to the `searchResult3` response:
+
+| Field | Type | Req. | Details |
+| --- | --- | --- | --- |
+| `totalArtistCount` | `int` | No | Total number of matching artists (may exceed returned count due to pagination). |
+| `totalAlbumCount` | `int` | No | Total number of matching albums. |
+| `totalSongCount` | `int` | No | Total number of matching songs. |
+
+This allows clients to show "Showing 20 of 1,432 results" and implement proper pagination UIs without guessing.
+
+## Version 2
+
+### Batch fetch endpoints
+
+New endpoints for fetching multiple items in a single request:
+
+- [`getAlbumsBatch`](../invalid) Fetch up to 50 albums by their IDs in a single call.
+- [`getSongsBatch`](../invalid) Fetch up to 50 songs by their IDs in a single call.
+- [`getArtistsBatch`](../invalid) Fetch up to 50 artists by their IDs in a single call.
+
+Each endpoint accepts an `id` parameter that can be specified multiple times (e.g., `id=1&id=2&id=3`), following the same pattern as `star`/`unstar`.
+
+### `stream` — Adaptive streaming mode
+
+A new optional parameter for the `stream` endpoint:
+
+| Parameter | Req. | Default | Comment |
+| --- | --- | --- | --- |
+| `streamMode` | No | `binary` | `binary`: current behavior (raw audio bytes). `redirect`: server returns a 302 redirect to the actual audio URL. `manifest`: server returns an HLS/DASH manifest if the source supports it. |
+
+Clients that support adaptive streaming can request `manifest` mode, which avoids server-side stream stitching. The `redirect` mode is useful for native apps that can handle direct URLs and don't need the server to proxy bytes.
+
+## Version 3
+
+### Discovery types for cloud catalogs
+
+New values for the `type` parameter in `getAlbumList2`:
+
+| Type | Description |
+| --- | --- |
+| `trending` | Currently popular on the platform. |
+| `recommended` | Personalized recommendations for the authenticated user. |
+
+### Server library type
+
+The `ping` / `subsonic-response` is extended with:
+
+| Field | Type | Req. | Details |
+| --- | --- | --- | --- |
+| `libraryType` | `string` | No | `local`, `remote`, or `hybrid`. Indicates whether the server hosts files locally, proxies a remote catalog, or both. |
+
+Clients can use this to adjust their UI — for example, hiding "scan library" buttons for remote servers, or disabling offline sync for catalogs that are too large.

--- a/content/en/docs/Responses/AlbumID3.md
+++ b/content/en/docs/Responses/AlbumID3.md
@@ -112,6 +112,7 @@ description: >
 | `artist` | `string` | No |     | Artist name.  |
 | `artistId` | `string` | No |    | The id of the artist |
 | `coverArt` | `string` | No |     | A covertArt id.  |
+| `coverArtUrl` | `string` | No | **Yes** | A direct URL to the cover art image. Clients SHOULD prefer this over calling `getCoverArt` when available. `infiniteLibrary` extension. |
 | `songCount` | `int` | **Yes** |     | Number of songs |
 | `duration` | `int` | **Yes** |     | Total duration of the album in seconds |
 | `playCount` | `long` | No |     | Number of play of the album |
@@ -153,6 +154,7 @@ New fields are added:
 - `isCompilation`
 - `discTitles`
 - `explicitStatus`
+- `coverArtUrl` (`infiniteLibrary` extension)
 
 **Note**: All OpenSubsonic added fields are **optionals**. But if a server support a field it **must** return it with an empty / default value when not present in it's database so that clients knows what the server supports.
 

--- a/content/en/docs/Responses/error.md
+++ b/content/en/docs/Responses/error.md
@@ -46,3 +46,4 @@ The following error codes are defined:
 | 50   | User is not authorized for the given operation.                                                                       |
 | 60   | The trial period for the Subsonic server is over. Please upgrade to Subsonic Premium. Visit subsonic.org for details. |
 | 70   | The requested data was not found.                                                                                     |
+| 71   | The requested operation would return too many results. The client should refine the query. (`infiniteLibrary` extension) |

--- a/content/en/docs/Responses/searchResult3.md
+++ b/content/en/docs/Responses/searchResult3.md
@@ -136,3 +136,6 @@ description: >
 | `artist` | Array of [`ArtistID3`](../artistid3) | No |     | Matching artists |
 | `album` | Array of [`AlbumID3`](../albumid3) | No |     |  Matching albums  |
 | `song` | Array of [`Child`](../child) | No |     | Matching songs |
+| `totalArtistCount` | `int` | No | **Yes** | Total number of matching artists (may exceed returned count due to pagination). `infiniteLibrary` extension. |
+| `totalAlbumCount` | `int` | No | **Yes** | Total number of matching albums. `infiniteLibrary` extension. |
+| `totalSongCount` | `int` | No | **Yes** | Total number of matching songs. `infiniteLibrary` extension. |


### PR DESCRIPTION
## Summary

This PR introduces the `infiniteLibrary` OpenSubsonic extension to address scalability and determinism challenges that arise when a server is backed by a very large or cloud-hosted music catalog (e.g., Tidal, Qobuz, or self-hosted collections with 100K+ items).

## Motivation

Several existing endpoints were designed with the assumption that the server has a small, fully-indexed local library. When libraries grow to millions of items, or when the server proxies an external catalog:

- **String-based artist lookups become ambiguous** — `getTopSongs(artist="Savant")` could match multiple unrelated artists. Meanwhile, `getSimilarSongs2` correctly uses an `id` parameter. This inconsistency is addressed.
- **Returning all result types wastes resources** — A client searching only for albums must still trigger artist and song searches. The behavior of `artistCount=0` is undefined across implementations.
- **N+1 cover art fetching** — Displaying 25 search results requires 25 additional `getCoverArt` calls when direct URLs could be embedded.
- **Binary-only streaming** — Cloud services deliver audio via HLS/DASH manifests, forcing proxy servers to stitch segments. This is CPU-intensive and adds latency.
- **Empty query sync is impractical** — Returning "all data" for infinite catalogs is not feasible.

## Changes (all backward-compatible)

### New extension file
- `Extensions/infiniteLibrary.md` — Formal extension definition (v1/v2/v3)

### Modified endpoints
- **`getTopSongs`**: Added optional `artistId` parameter for deterministic ID-based resolution
- **`search3`**: Added `type` filter parameter, clarified zero-count semantics
- **`stream`**: Added `streamMode` parameter (`binary`/`redirect`/`manifest`)

### Modified responses
- **`searchResult3`**: Added `totalArtistCount`, `totalAlbumCount`, `totalSongCount` fields for proper pagination
- **`AlbumID3`**: Added `coverArtUrl` field for direct CDN artwork URLs
- **`error`**: Added error code `71` (result set too large)

## Design Principles

1. **All changes are optional** — Servers declare support via `getOpenSubsonicExtensions`
2. **All new parameters have defaults matching current behavior** — No existing client breaks
3. **All new response fields are additive** — Clients that don't understand them ignore them
4. **Follows the existing extension template format exactly**

## Real-World Validation

These proposals come from practical implementation experience building [Substream](https://github.com/soyelmismo/substream), a Subsonic-compatible proxy for Tidal with 100M+ items. Each issue was discovered through real client behavior (Feishin, Aonsoku, Supersonic) connecting to cloud-backed catalogs.

## Complexity Analysis

| Operation | Current Protocol | With Extension |
|---|---|---|
| Artist top songs lookup | O(n) fuzzy search | O(1) ID lookup |
| Search (artist-only) | 3 parallel searches | 1 targeted search |
| Cover art (25 results) | 25 HTTP calls | 0 calls (URL embedded) |
| Stream initiation | 2-5s (proxy stitch) | <100ms (redirect) |