### PR TITLE
Add groupings field

### DIFF
--- a/content/en/docs/Responses/Child.md
+++ b/content/en/docs/Responses/Child.md
@@ -135,7 +135,8 @@ description: >
       "number": 2,
       "count": 4
     }
-  ]
+  ],
+  "groupings": ["Soundtrack", "Live"]
 }
 {{< /tab >}}
 {{< tab header="Subsonic" lang="json" >}}
@@ -225,6 +226,7 @@ description: >
 | `explicitStatus` | `string` | No |  **Yes**    | Returns "explicit", "clean" or "". (For songs extracted from tags "ITUNESADVISORY": 1 = explicit, 2 = clean, MP4 "rtng": 1 or 4 = explicit, 2 = clean. See [`albumID3`](../albumid3) for albums) |
 | `works` | Array of [`Work`](../work) | No |  **Yes**   | The list of works associated with the song. |
 | `movements` | Array of [`Movement`](../movement) | No |  **Yes**   | The list of movements associated with the song. |
+| `groupings` | Array of `string` | No |  **Yes**   | The list of groupings associated with the song. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 New fields are added:
@@ -247,6 +249,7 @@ New fields are added:
 - `explicitStatus`
 - `works`
 - `movements`
+- `groupings`
 
 **Note**: All OpenSubsonic added fields are **optionals**. But if a server support a field it **must** return it with an empty / default value when not present in it's database so that clients knows what the server supports.
 

--- a/openapi/schemas/Child.json
+++ b/openapi/schemas/Child.json
@@ -245,6 +245,13 @@
                 "$ref": "./Movement.json"
             },
             "description": "The list of movements associated with the song."
+        },
+        "groupings": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "description": "The list of groupings associated with the song."
         }
     },
     "required": [


### PR DESCRIPTION
Add an optional `groupings` field to the `Child` response.

It is the representation of:

|  Unified | ID3v2.3 | ID3v2.4 |  MP4 | ASF |  Vorbis  |
|:--------:|:-------:|:-------:|:----:|:---:|:--------:|
| Grouping | GRP1    | GRP1    | ©grp |     | GROUPING |

https://kid3.sourceforge.io/kid3_en.html#frame-list

The grouping tag is used to categorize tracks into a broader group beyond just the album. I have not found an accurate description but people on the web started to use it for various use cases.

It is common for me to use multiple values for the field (through Navidrome string splitter) so I decided to go with an array. I agree with the same motivation from https://github.com/opensubsonic/open-subsonic-api/pull/212#issuecomment-3933781662: It is still possible to just use an array of size 1 to simulate a single value.

A few examples of my usage:
- The music source: CD, Bandcamp, Qobuz
- The music type: Christmas, Soundtrack, Kid (i do not find genres would fit)

An discussion is also already opened: https://github.com/opensubsonic/open-subsonic-api/discussions/182. Although without an answer, it received a few upvotes already.