### PR TITLE
Fix broken site search by switching to Lunr.js offline search

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -126,17 +126,13 @@ github_repo = "https://github.com/opensubsonic/open-subsonic-api"
 github_branch= "master"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
-gcs_engine_id = "d72aa9b2712488cc3"
+# gcs_engine_id = "d72aa9b2712488cc3"
 
 # Enable Lunr.js offline search
-offlineSearch = false
+offlineSearch = true
 
 # Enable syntax highlighting and copy buttons on code blocks with Prism
 prism_syntax_highlighting = false
-
-[params.seach]
-# Enable Algolia DocSearch
-algolia = false
 
 # User interface configuration
 [params.ui]


### PR DESCRIPTION
## Summary
- Site search was broken because it relied on Google Custom Search Engine (GCSE) which stopped working
- Switched to Lunr.js offline search (`offlineSearch = true`), which builds a local index at build time with no external dependency
- Removed misconfigured `[params.seach]` section (typo in name) with `algolia = false`, which caused Docsy template errors (tried to access `.appId` on a boolean)

## Test plan
- [x] Verified Hugo builds without errors or warnings
- [x] Confirmed search box returns results from local Lunr.js index in browser
- [x] Compared against working search on navidrome/website (same approach: `offlineSearch: true`)