### PR TITLE
openapi: fix broken DirectPlayProfile schema

### DIFF
--- a/openapi/schemas/DirectPlayProfile.json
+++ b/openapi/schemas/DirectPlayProfile.json
@@ -7,7 +7,7 @@
       "description" : "The list of supported containers. An empty array means any containers.",
       "items": {
         "type": "string",
-        "example": "mp4",
+        "example": "mp4"
       }
     },
     "audioCodecs": {


### PR DESCRIPTION
Remove erroneous trailing comma in object.
