### PR TITLE
Update links for Nextcloud Music

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -35,7 +35,7 @@ Any server or client can join the organization and make proposals for [OpenSubso
 | [gonic](https://github.com/sentriz/gonic) | [Documentation](https://github.com/sentriz/gonic/wiki/subsonic-api-compatibility)  |
 | [LMS - Lightweight Music Server](https://github.com/epoupon/lms) | [Documentation](https://github.com/epoupon/lms/blob/master/SUBSONIC.md)  |
 | [Navidrome](https://www.navidrome.org/)  | [Documentation](https://www.navidrome.org/docs/developers/subsonic-api)  |
-| [Nextcloud Music / ownCloud Music](https://github.com/owncloud/music)  | [Documentation](https://github.com/owncloud/music/wiki/OpenSubsonic-API)   |
+| [Nextcloud Music](https://github.com/nc-music/music)  | [Documentation](https://github.com/nc-music/music/wiki/OpenSubsonic-API)   |
 | [Qm-Music](https://github.com/chenqimiao/qm-music) | - |
 | [Radiccio Server](https://radiccio.music/server) | [Documentation](https://api-docs.radiccio.music/opensubsonic/) |
 | [Supysonic](https://github.com/spl0k/supysonic) | - |


### PR DESCRIPTION
As of the beginning of this year, the ownCloud version of my server has been in maintenance mode and all new development has been made only for the Nextcloud version. This development happens under a new github repository https://github.com/nc-music/music while the old repository under the owncloud organization is used for the maintenance project.

As the "classic" ownCloud is more or less a dying platform with diminishing user base, there's no need to advertise this version in the OS documentation.