### PR TITLE
Clarify cueLine value semantics

### DIFF
--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -278,12 +278,15 @@ Does not exist.
 
 ##### Example with background vocals (agents + agentId)
 
-When a source distinguishes both a lead/default vocal layer and background vocals within the same lyric line, the server emits a shared `agents` array on that `structuredLyrics` entry and splits the lyric into separate cueLines with the same `index`. Each cueLine references one agent via `agentId`, and the cueLine whose referenced agent has `role: "main"` comes first:
+When a source distinguishes both a lead/default vocal layer and background vocals within the same lyric line, the server emits a shared `agents` array on that `structuredLyrics` entry and splits the lyric into separate cueLines with the same `index`. Each cueLine references one agent via `agentId`, contains that agent/layer's renderable text in `value`, and the cueLine whose referenced agent has `role: "main"` comes first. The parent `line` remains the combined fallback line:
 
 {{< tabpane persist=false >}}
 {{< tab header="**Example**:" disabled=true />}}
 {{< tab header="OpenSubsonic JSON" lang="json">}}
 {
+  "line": [
+    { "start": 1000, "value": "Hello echo" }
+  ],
   "agents": [
     { "id": "lead", "role": "main", "name": "Lead Vocal" },
     { "id": "backing", "role": "bg" }
@@ -294,7 +297,7 @@ When a source distinguishes both a lead/default vocal layer and background vocal
       "agentId": "lead",
       "start": 1000,
       "end": 3000,
-      "value": "Hello echo",
+      "value": "Hello",
       "cue": [
         { "start": 1000, "end": 1400, "value": "He", "byteStart": 0, "byteEnd": 1 },
         { "start": 1400, "end": 1800, "value": "llo", "byteStart": 2, "byteEnd": 4 }
@@ -305,23 +308,24 @@ When a source distinguishes both a lead/default vocal layer and background vocal
       "agentId": "backing",
       "start": 1000,
       "end": 3000,
-      "value": "Hello echo",
+      "value": "echo",
       "cue": [
-        { "start": 2000, "end": 2500, "value": "echo", "byteStart": 6, "byteEnd": 9 }
+        { "start": 2000, "end": 2500, "value": "echo", "byteStart": 0, "byteEnd": 3 }
       ]
     }
   ]
 }
 {{< /tab >}}
 {{< tab header="OpenSubsonic XML" lang="xml">}}
+<line start="1000">Hello echo</line>
 <agent id="lead" role="main" name="Lead Vocal" />
 <agent id="backing" role="bg" />
-<cueLine index="0" agentId="lead" start="1000" end="3000" value="Hello echo">
+<cueLine index="0" agentId="lead" start="1000" end="3000" value="Hello">
   <cue start="1000" end="1400" byteStart="0" byteEnd="1">He</cue>
   <cue start="1400" end="1800" byteStart="2" byteEnd="4">llo</cue>
 </cueLine>
-<cueLine index="0" agentId="backing" start="1000" end="3000" value="Hello echo">
-  <cue start="2000" end="2500" byteStart="6" byteEnd="9">echo</cue>
+<cueLine index="0" agentId="backing" start="1000" end="3000" value="echo">
+  <cue start="2000" end="2500" byteStart="0" byteEnd="3">echo</cue>
 </cueLine>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -473,6 +477,7 @@ Servers that don't support TTML or word-level timing simply never include these 
 - Within a `cueLine`, `cue.end` **must** be either present on **all** cues or **none** (all-or-nothing). When the source provides partial end times, servers **must** fill missing values. When no cues have end times, `end` is omitted from all cues. This is a documented contract rule; the OpenAPI schema does not encode the all-or-none shape structurally.
 - `agents` are scoped to a single `structuredLyrics` entry. When present, `agents` **must** contain at least one entry, and each `agents[].id` **must** be unique within that entry. `agents` are optional for simple unattributed single-layer lyrics. When a `structuredLyrics` entry represents multiple vocal agents/layers, it **must** include `agents`; a single-agent attributed/default entry may also include `agents`, and if it does, exactly one agent **must** use `role: "main"`. `agents` should not be emitted without `cueLine` data.
 - When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first. Clients should not assume every source can distinguish or emit multiple agents.
+- When multiple agent cueLines share the same `index`, each `cueLine.value` **must** be independently renderable for that agent/layer. Clients should use `structuredLyrics.line[index].value` as the combined fallback line, not as the per-agent cueLine text.
 - If `agents` is present, every `cueLine` in that entry **must** include `agentId`, and each `agentId` **must** match exactly one `agents[].id` in that entry. If `agents` is absent, cueLines **must not** include `agentId`.
 - Every cue **must** include `byteStart` / `byteEnd`, and every `cueLine` **must** include `value`. The offsets are 0-based inclusive positions into the final UTF-8 encoding of that `cueLine.value`, with no normalization step, and `byteStart` **must** be ≤ `byteEnd`. The OpenAPI schema enforces the presence of these fields, but not the cross-field ordering constraint structurally.
 - Cues within a `cueLine` **must not** overlap (i.e. `cue[n].end` **must** be ≤ `cue[n+1].start`). Servers **must** normalize any source overlaps so that clients can iterate cues sequentially without overlap-resolution logic. Overlapping timing across different cueLines (different `agentId` values) is expected, since those represent parallel vocal layers.

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -34,7 +34,7 @@ Adds:
 
 When agent attribution is present, the reusable agent metadata lives once in `structuredLyrics.agents`, while each `cueLine` points at the relevant agent via `agentId`. Simple unattributed single-layer lyrics may omit `agents` entirely. Entries with multiple vocal agents/layers **must** emit `agents`, and every attributed entry that uses `agents` **must** define exactly one `role: "main"` agent. A single-agent attributed/default layer may also use `agents` with that lone agent marked as `main`.
 
-Each cue includes `byteStart` / `byteEnd`, defined as 0-based inclusive offsets into the UTF-8 encoding of the final parent `cueLine.value`, with no normalization step. Accordingly, each `cueLine` that contains cues must also include `value`.
+Each cue includes `byteStart` / `byteEnd`, defined as 0-based inclusive offsets into the UTF-8 encoding of the final `cueLine.value`, with no normalization step. Accordingly, each `cueLine` that contains cues must also include `value`. When multiple agent cueLines share one parent line index, each `cueLine.value` is the renderable text for that agent/layer, not necessarily the parent line's combined text.
 
 All new fields are gated behind `enhanced=true` — without it, the response is identical to version 1.
 

--- a/content/en/docs/Responses/cueLine.md
+++ b/content/en/docs/Responses/cueLine.md
@@ -4,7 +4,7 @@ linkTitle: "cueLine [OS]"
 opensubsonic:
   - Addition
 description: >
-  Word/syllable-level timing data for a lyrics line.
+  Word/syllable-level timing data for a lyrics line or agent layer.
 ---
 
 {{< tabpane persist=false >}}
@@ -110,7 +110,7 @@ Does not exist.
 | `index`   | `integer`                | **Yes** | **Yes** | Zero-based index into the parent `line` array this cueLine corresponds to                                                                                                                                                                                                                                                                                    |
 | `start`   | `integer`                | No      | **Yes** | Start time in milliseconds (may differ from the parent line if cues are more precise)                                                                                                                                                                                                                                                                        |
 | `end`     | `integer`                | No      | **Yes** | End time in milliseconds                                                                                                                                                                                                                                                                                                                                     |
-| `value`   | `string`                 | **Yes** | **Yes** | Full text of the line. Required because every nested [`cue`](../cue) defines `byteStart` / `byteEnd` against this exact final UTF-8 string                                                                                                                                                                                                                                                                                                                                       |
+| `value`   | `string`                 | **Yes** | **Yes** | Full text for this cueLine. When agent attribution splits one parent line into multiple cueLines, this is the text for that cueLine's agent/layer, not necessarily the parent line's combined text. Required because every nested [`cue`](../cue) defines `byteStart` / `byteEnd` against this exact final UTF-8 string                                                                                             |
 | `agentId` | `string`                 | No      | **Yes** | Opaque identifier referencing an [`agent`](../agent) in the same [`structuredLyrics`](../structuredlyrics) entry. If the parent `structuredLyrics` entry includes `agents`, every cueLine in that entry **must** include `agentId`, and the value **must** match exactly one `agents[].id` in that entry. If the parent entry does not include `agents`, cueLines **must not** include `agentId`. When multiple cueLines share the same `index`, the cueLine whose referenced agent has `role: "main"` **must** come first |
 | `cue`     | Array of [`cue`](../cue) | **Yes** | **Yes** | Ordered list of word/syllable cues. Every cue **must** include `byteStart` / `byteEnd` offsets into `value`                                                                                                                                                                                                                                                                                                                       |
 

--- a/openapi/schemas/CueLine.json
+++ b/openapi/schemas/CueLine.json
@@ -1,6 +1,6 @@
 {
   "type": "object",
-  "description": "Word/syllable-level timing data for a lyrics line",
+  "description": "Word/syllable-level timing data for a lyrics line or agent layer",
   "externalDocs": {
     "description": "CueLine",
     "url": "https://opensubsonic.netlify.app/docs/responses/cueline/"
@@ -20,7 +20,7 @@
     },
     "value": {
       "type": "string",
-      "description": "Required full text of the line. Nested cue byteStart and byteEnd offsets are always calculated against this exact final UTF-8 string"
+      "description": "Required full text for this cueLine. When agent attribution splits one parent line into multiple cueLines, this is the text for that cueLine's agent/layer, not necessarily the parent line's combined text. Nested cue byteStart and byteEnd offsets are always calculated against this exact final UTF-8 string"
     },
     "agentId": {
       "type": "string",

--- a/openapi/schemas/StructuredLyrics.json
+++ b/openapi/schemas/StructuredLyrics.json
@@ -52,7 +52,7 @@
         },
         "cueLine": {
             "type": "array",
-            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. Every cueLine includes value, and every cue includes byteStart and byteEnd offsets into that exact string. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Only returned when enhanced=true and synced is true",
+            "description": "Word/syllable-level timing data. Each cueLine corresponds to a line in this structuredLyrics entry by its index field. Every cueLine includes value, and every cue includes byteStart and byteEnd offsets into that exact string. When agents split one parent line into multiple cueLines, each cueLine.value is the renderable text for that agent/layer, not necessarily the parent line's combined text. If agents is present, every cueLine in the entry must include agentId, and each agentId must match exactly one agents[].id in that entry. If agents is absent, cueLines must not include agentId. Only returned when enhanced=true and synced is true",
             "items": {
                 "$ref": "./CueLine.json"
             }


### PR DESCRIPTION
## Summary

- Clarify that `cueLine.value` is the renderable text for that cueLine/agent layer, not necessarily the parent line's combined text.
- Update the background-vocals example to keep `line.value` as the combined fallback while using agent-local cueLine values and offsets.
- Mirror the clarified wording in the OpenAPI schema descriptions.