### PR TITLE
Add `artistRoleFilter` extension

### DIFF
--- a/content/en/docs/Endpoints/getartists.md
+++ b/content/en/docs/Endpoints/getartists.md
@@ -19,14 +19,14 @@ Similar to [`getIndexes`](../getindexes), but organizes music according to ID3 t
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
 | `musicFolderId` | No  |  |  | If specified, only return artists in the music folder with the given ID. See [`getMusicFolders`](../getmusicfolders). |
-| `roles` | No | No / **Yes** |  | A comma-separated list of roles used to filter the returned artists. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
+| `role` | No | **Yes** |  | Repeat this parameter to filter the returned artists by one or more roles. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
-If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `roles` parameter and filter the returned artists accordingly.
+If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `role` parameter and filter the returned artists accordingly.
 
-`roles` is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
+`role` may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
 
-The behavior when `roles` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
+The behavior when `role` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Endpoints/getartists.md
+++ b/content/en/docs/Endpoints/getartists.md
@@ -26,7 +26,7 @@ If the server supports the [`Artist role filter`](../../extensions/artistRoleFil
 
 `role` may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
 
-The behavior when `role` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
+When `role` is omitted the server returns what it does today, so the extension is purely additive and existing clients are unaffected.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Endpoints/getartists.md
+++ b/content/en/docs/Endpoints/getartists.md
@@ -1,6 +1,9 @@
 ---
 title: "getArtists"
-linkTitle: "getArtists"
+linkTitle: "getArtists [OS]"
+opensubsonic:
+- Addition
+- Extension
 categories:
 - Browsing
 description: >
@@ -16,6 +19,15 @@ Similar to [`getIndexes`](../getindexes), but organizes music according to ID3 t
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
 | `musicFolderId` | No  |  |  | If specified, only return artists in the music folder with the given ID. See [`getMusicFolders`](../getmusicfolders). |
+| `roles` | No | No / **Yes** |  | A comma-separated list of roles used to filter the returned artists. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
+
+{{< alert color="warning" title="OpenSubsonic" >}}
+If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `roles` parameter and filter the returned artists accordingly.
+
+`roles` is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
+
+The behavior when `roles` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
+{{< /alert >}}
 
 ### Example
 

--- a/content/en/docs/Endpoints/getopensubsonicextensions.md
+++ b/content/en/docs/Endpoints/getopensubsonicextensions.md
@@ -56,6 +56,12 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
                 "versions": [
                     1
                 ]
+            },
+            {
+                "name": "artistRoleFilter",
+                "versions": [
+                    1
+                ]
             }
         ]
     }

--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -36,7 +36,7 @@ Servers must support an **empty query** and return all the data to allow clients
 
 If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `artistRole` parameter and filter the returned **artists** accordingly (albums and songs are unaffected).
 
-`artistRole` may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role. The behavior when `artistRole` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
+`artistRole` may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role. When `artistRole` is omitted the server returns what it does today, so the extension is purely additive and existing clients are unaffected.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -3,6 +3,8 @@ title: "search3"
 linkTitle: "search3 [OS]"
 opensubsonic:
 - Clarification
+- Addition
+- Extension
 categories:
 - Searching
 description: >
@@ -27,9 +29,14 @@ Music is organized according to ID3 tags.
 | `songCount` | No |   | 20  | Maximum number of songs to return. |
 | `songOffset` | No |   | 0   | Search result offset for songs. Used for paging. |
 | `musicFolderId` | No |   |     | (Since [1.12.0](../../subsonic-versions)) Only return results from music folder with the given ID. See `getMusicFolders`. |
+| `artistRoles` | No | No / **Yes** |     | A comma-separated list of roles used to filter the returned artists. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 Servers must support an **empty query** and return all the data to allow clients to properly access all the media information for offline sync.
+
+If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `artistRoles` parameter and filter the returned **artists** accordingly (albums and songs are unaffected).
+
+`artistRoles` is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role. The behavior when `artistRoles` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Endpoints/search3.md
+++ b/content/en/docs/Endpoints/search3.md
@@ -29,14 +29,14 @@ Music is organized according to ID3 tags.
 | `songCount` | No |   | 20  | Maximum number of songs to return. |
 | `songOffset` | No |   | 0   | Search result offset for songs. Used for paging. |
 | `musicFolderId` | No |   |     | (Since [1.12.0](../../subsonic-versions)) Only return results from music folder with the given ID. See `getMusicFolders`. |
-| `artistRoles` | No | No / **Yes** |     | A comma-separated list of roles used to filter the returned artists. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
+| `artistRole` | No | **Yes** |     | Repeat this parameter to filter the returned artists by one or more roles. Requires the [`Artist role filter`](../../extensions/artistRoleFilter/) extension. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 Servers must support an **empty query** and return all the data to allow clients to properly access all the media information for offline sync.
 
-If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `artistRoles` parameter and filter the returned **artists** accordingly (albums and songs are unaffected).
+If the server supports the [`Artist role filter`](../../extensions/artistRoleFilter/) extension, it **must** accept the `artistRole` parameter and filter the returned **artists** accordingly (albums and songs are unaffected).
 
-`artistRoles` is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role. The behavior when `artistRoles` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
+`artistRole` may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role. The behavior when `artistRole` is **not** provided is left to the server (historically, returning only album artists), so that existing clients are unaffected.
 {{< /alert >}}
 
 ### Example

--- a/content/en/docs/Extensions/artistRoleFilter.md
+++ b/content/en/docs/Extensions/artistRoleFilter.md
@@ -21,6 +21,6 @@ Historically these endpoints return only album artists. Some clients want the fu
 
 The parameter may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
 
-The behavior when the parameter is **not** provided is left to the server (historically, returning only album artists) so that existing clients are unaffected. On [`search3`](../../endpoints/search3), the parameter only affects the returned artists; albums and songs are unaffected.
+When the parameter is omitted the server returns what it does today, so the extension is purely additive and existing clients are unaffected. On [`search3`](../../endpoints/search3), the parameter only affects the returned artists; albums and songs are unaffected.
 
 This extension requires the support of the `role` parameter of [`getArtists`](../../endpoints/getartists) and the `artistRole` parameter of [`search3`](../../endpoints/search3).

--- a/content/en/docs/Extensions/artistRoleFilter.md
+++ b/content/en/docs/Extensions/artistRoleFilter.md
@@ -11,7 +11,7 @@ description: >
 
 **OpenSubsonic extension name**: `artistRoleFilter` (As returned by [`getOpenSubsonicExtensions`](../../endpoints/getopensubsonicextensions))
 
-When a server supports this extension it means that it supports filtering the returned artists by role: the `roles` parameter of the [`getArtists`](../../endpoints/getartists) endpoint and the `artistRoles` parameter of the [`search3`](../../endpoints/search3) endpoint. (The parameter is named `artistRoles` on `search3` to disambiguate it from that endpoint's album and song results.)
+When a server supports this extension it means that it supports filtering the returned artists by role: the `role` parameter of the [`getArtists`](../../endpoints/getartists) endpoint and the `artistRole` parameter of the [`search3`](../../endpoints/search3) endpoint. (The parameter is named `artistRole` on `search3` to disambiguate it from that endpoint's album and song results.)
 
 ## Version 1
 
@@ -19,8 +19,8 @@ You can now filter the artists returned by [`getArtists`](../../endpoints/getart
 
 Historically these endpoints return only album artists. Some clients want the full set of artists (composers, track artists, etc.) - for example to mirror the whole library - while legacy clients rely on the album-artist-only behavior. This extension lets the client, rather than the server, decide.
 
-The parameter value is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
+The parameter may be repeated to request several roles, using the values found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
 
 The behavior when the parameter is **not** provided is left to the server (historically, returning only album artists) so that existing clients are unaffected. On [`search3`](../../endpoints/search3), the parameter only affects the returned artists; albums and songs are unaffected.
 
-This extension requires the support of the `roles` parameter of [`getArtists`](../../endpoints/getartists) and the `artistRoles` parameter of [`search3`](../../endpoints/search3).
+This extension requires the support of the `role` parameter of [`getArtists`](../../endpoints/getartists) and the `artistRole` parameter of [`search3`](../../endpoints/search3).

--- a/content/en/docs/Extensions/artistRoleFilter.md
+++ b/content/en/docs/Extensions/artistRoleFilter.md
@@ -1,0 +1,26 @@
+---
+title: "Artist role filter"
+linkTitle: "Artist role filter"
+OpenSubsonic:
+- Extension
+description: >
+  Add support for filtering artist lists by artist role.
+---
+
+**OpenSubsonic version**: [1](../../opensubsonic-versions)
+
+**OpenSubsonic extension name**: `artistRoleFilter` (As returned by [`getOpenSubsonicExtensions`](../../endpoints/getopensubsonicextensions))
+
+When a server supports this extension it means that it supports filtering the returned artists by role: the `roles` parameter of the [`getArtists`](../../endpoints/getartists) endpoint and the `artistRoles` parameter of the [`search3`](../../endpoints/search3) endpoint. (The parameter is named `artistRoles` on `search3` to disambiguate it from that endpoint's album and song results.)
+
+## Version 1
+
+You can now filter the artists returned by [`getArtists`](../../endpoints/getartists) and [`search3`](../../endpoints/search3) by role, letting clients choose whether they want album artists, track artists, or every artist regardless of role.
+
+Historically these endpoints return only album artists. Some clients want the full set of artists (composers, track artists, etc.) - for example to mirror the whole library - while legacy clients rely on the album-artist-only behavior. This extension lets the client, rather than the server, decide.
+
+The parameter value is a comma-separated list of roles as found in the [`ArtistID3`](../../responses/artistid3) `roles` field (e.g. `albumartist`, `artist`, `composer`). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role.
+
+The behavior when the parameter is **not** provided is left to the server (historically, returning only album artists) so that existing clients are unaffected. On [`search3`](../../endpoints/search3), the parameter only affects the returned artists; albums and songs are unaffected.
+
+This extension requires the support of the `roles` parameter of [`getArtists`](../../endpoints/getartists) and the `artistRoles` parameter of [`search3`](../../endpoints/search3).

--- a/content/en/docs/opensubsonic-versions.md
+++ b/content/en/docs/opensubsonic-versions.md
@@ -12,7 +12,7 @@ This table shows the supported extensions by OpenSubsonic versions:
 
 | OpenSubsonic version | Supported extension |
 | --- | --- |
-| 1 | [Template extension](../extensions/template), [Sonic similarity](../extensions/sonicSimilarity) |
+| 1 | [Template extension](../extensions/template), [Sonic similarity](../extensions/sonicSimilarity), [Artist role filter](../extensions/artistRoleFilter) |
 
 **Note**: Since extensions are optional, more extensions can be added over time to the same OpenSubsonic API version.
 

--- a/openapi/endpoints/getArtists.json
+++ b/openapi/endpoints/getArtists.json
@@ -17,12 +17,17 @@
                 }
             },
             {
-                "name": "roles",
+                "name": "role",
                 "in": "query",
-                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined.",
+                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. Repeat this parameter to filter the returned artists by one or more roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`); an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined.",
                 "required": false,
+                "explode": true,
+                "style": "form",
                 "schema": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         ],
@@ -61,9 +66,12 @@
                                 "type": "string",
                                 "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`."
                             },
-                            "roles": {
-                                "type": "string",
-                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined."
+                            "role": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. Repeat this parameter to filter the returned artists by one or more roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`); an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined."
                             }
                         }
                     }

--- a/openapi/endpoints/getArtists.json
+++ b/openapi/endpoints/getArtists.json
@@ -15,6 +15,15 @@
                 "schema": {
                     "type": "string"
                 }
+            },
+            {
+                "name": "roles",
+                "in": "query",
+                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
             }
         ],
         "responses": {
@@ -51,6 +60,10 @@
                             "musicFolderId": {
                                 "type": "string",
                                 "description": "If specified, only return artists in the music folder with the given ID. See `getMusicFolders`."
+                            },
+                            "roles": {
+                                "type": "string",
+                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. When omitted, the behavior is server-defined."
                             }
                         }
                     }

--- a/openapi/endpoints/search3.json
+++ b/openapi/endpoints/search3.json
@@ -91,6 +91,15 @@
                 "schema": {
                     "type": "string"
                 }
+            },
+            {
+                "name": "artistRoles",
+                "in": "query",
+                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined.",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
             }
         ],
         "responses": {
@@ -168,6 +177,10 @@
                             "musicFolderId": {
                                 "type": "string",
                                 "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
+                            },
+                            "artistRoles": {
+                                "type": "string",
+                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined."
                             }
                         },
                         "required": [

--- a/openapi/endpoints/search3.json
+++ b/openapi/endpoints/search3.json
@@ -93,12 +93,17 @@
                 }
             },
             {
-                "name": "artistRoles",
+                "name": "artistRole",
                 "in": "query",
-                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined.",
+                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. Repeat this parameter to filter the returned artists by one or more roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`); an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined.",
                 "required": false,
+                "explode": true,
+                "style": "form",
                 "schema": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         ],
@@ -178,9 +183,12 @@
                                 "type": "string",
                                 "description": "(Since 1.12.0) Only return albums in the music folder with the given ID. See `getMusicFolders`."
                             },
-                            "artistRoles": {
-                                "type": "string",
-                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. A comma-separated list of roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`) used to filter the returned artists; an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined."
+                            "artistRole": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "description": "Requires the `artistRoleFilter` OpenSubsonic extension. Repeat this parameter to filter the returned artists by one or more roles (as in `ArtistID3.roles`, e.g. `albumartist`, `artist`, `composer`); an artist is returned if it has any of the requested roles. The special value `all` returns every artist regardless of role. Only affects the returned artists (albums and songs are unaffected). When omitted, the behavior is server-defined."
                             }
                         },
                         "required": [


### PR DESCRIPTION
`getArtists` (and the artist results of `search3`) historically return **album artists only**. This is the original Subsonic behavior, and legacy clients like DSub depend on it: if a server started returning track-level artists, those clients would be flooded with thousands of artists users don't care about - featured/track artists and composers dragged in from compilation albums, soundtracks, etc.

At the same time, modern OpenSubsonic clients need the opposite. A client that mirrors/syncs the whole library (e.g. Symfonium, which bulk-fetches artists via `search3` with an empty query), or one that lets users browse by composer or track artist, wants **all** artists.

Today there's no way for a client to say which it wants - the behavior is server-defined and inconsistent across implementations:

| Server | `getArtists` returns |
| --- | --- |
| Airsonic (legacy Subsonic) | album artists only |
| gonic | album artists only |
| Navidrome | album artists only |
| LMS | configurable per-user server setting, defaults to *all* artists |

## Proposal

A new optional OpenSubsonic extension, **`artistRoleFilter`**, that lets the **client** choose, via a role filter:

- `getArtists`: new `roles` parameter
- `search3`: new `artistRoles` parameter (named to disambiguate from that endpoint's album/song results)

The value is a comma-separated list of roles matching the existing [`ArtistID3.roles`](https://opensubsonic.netlify.app/docs/responses/artistid3/) vocabulary (`albumartist`, `artist`, `composer`, ...). An artist is returned if it has **any** of the requested roles. The special value `all` returns every artist regardless of role (roles are open-ended - performer, arranger, producer, subroles - so clients wanting "everyone" shouldn't have to enumerate them).

**The behavior when the parameter is omitted is deliberately left to the server** (historically, album artists only). This means:
- Legacy clients are completely unaffected - nothing changes unless a client opts in.
- Servers already returning all artists (LMS) don't have to change their default.
- Clients that need a guarantee can request `roles=albumartist` or `roles=all` explicitly.