### PR TITLE
Add `ArtistID3.disambiguation` field

### DIFF
--- a/content/en/docs/Responses/ArtistID3.md
+++ b/content/en/docs/Responses/ArtistID3.md
@@ -20,6 +20,7 @@ description: >
   "starred": "2017-04-11T10:42:50.842Z",
   "musicBrainzId": "189002e7-3285-4e2e-92a3-7f6c30d407a2",
   "sortName": "Mello (2)",
+  "disambiguation": "French electronic duo",
   "roles": [
     "artist",
     "albumartist",
@@ -50,6 +51,7 @@ description: >
 | `starred` | `string` | No |     | Date the artist was starred. [ISO 8601]|
 | `musicBrainzId` | `string` | No |  **Yes**   | The artist MusicBrainzID. |
 | `sortName` | `string` | No |  **Yes**   | The artist sort name. |
+| `disambiguation` | `string` | No |  **Yes**   | A short human-readable comment, meant to be shown to users to distinguish between artists with the same name (e.g. `French electronic duo`). |
 | `roles` | Array of `string` | No | **Yes**    | The list of all roles this artist has in the library. |
 
 {{< alert color="warning" title="OpenSubsonic" >}}
@@ -57,6 +59,7 @@ New fields are added:
 
 - `musicBrainzId`
 - `sortName`
+- `disambiguation`
 - `roles`
 
 **Note**: All OpenSubsonic added fields are **optionals**. But if a server support a field it **must** return it with an empty / default value when not present in it's database so that clients knows what the server supports.

--- a/openapi/schemas/ArtistID3.json
+++ b/openapi/schemas/ArtistID3.json
@@ -35,6 +35,10 @@
             "type": "string",
             "description": "The artist sort name."
         },
+        "disambiguation": {
+            "type": "string",
+            "description": "A short human-readable comment, meant to be shown to users to distinguish between artists with the same name (e.g. 'French electronic duo')."
+        },
         "roles": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Add an optional `disambiguation` field to the ArtistID3 response element, a free-text comment used to distinguish between artists sharing the same name (e.g. MusicBrainz-style "French electronic duo" vs "drum & bass producer")

based on https://github.com/opensubsonic/open-subsonic-api/discussions/249
