### PR TITLE
Add `topSongsByArtistId` extension

### DIFF
--- a/content/en/docs/Endpoints/getopensubsonicextensions.md
+++ b/content/en/docs/Endpoints/getopensubsonicextensions.md
@@ -56,6 +56,12 @@ A [`subsonic-response`](../../responses/subsonic-response) element with a nested
                 "versions": [
                     1
                 ]
+            },
+            {
+                "name": "topSongsByArtistId",
+                "versions": [
+                    1
+                ]
             }
         ]
     }

--- a/content/en/docs/Endpoints/gettopsongs.md
+++ b/content/en/docs/Endpoints/gettopsongs.md
@@ -1,6 +1,9 @@
 ---
 title: "getTopSongs"
-linkTitle: "getTopSongs"
+linkTitle: "getTopSongs [OS]"
+opensubsonic:
+- Addition
+- Extension
 categories:
 - Browsing
 description: >
@@ -15,8 +18,15 @@ Returns top songs for the given artist, using data from [last.fm](http://last.fm
 
 | Parameter | Req. | OpenS. | Default | Comment |
 | --- | --- | --- | --- | --- |
-| `artist` | **Yes** |  |   | The artist name. |
+| `artist` | Yes, unless `id` is provided* |  |   | The artist name. |
+| `id` | No | **Yes** |   | The artist ID. Requires the [`topSongsByArtistId`](../../extensions/topsongsbyartistid/) extension. |
 | `count` | No  | |  50  | Max number of songs to return. |
+
+{{< alert color="warning" title="OpenSubsonic" >}}
+\* If the server supports the [`topSongsByArtistId`](../../extensions/topsongsbyartistid/) extension, it **must** accept the `id` parameter and return the top songs for the artist with that ID. When `id` is provided, `artist` is not required, and `id` takes precedence over it.
+
+On servers without the extension, `id` is ignored and `artist` remains required.
+{{< /alert >}}
 
 ### Example
 

--- a/content/en/docs/Extensions/topSongsByArtistId.md
+++ b/content/en/docs/Extensions/topSongsByArtistId.md
@@ -1,0 +1,20 @@
+---
+title: "Top songs by artist ID"
+linkTitle: "Top songs by artist ID"
+OpenSubsonic:
+- Extension
+description: >
+  Add support for retrieving top songs by artist ID.
+---
+
+**OpenSubsonic version**: [1](../../opensubsonic-versions)
+
+**OpenSubsonic extension name**: `topSongsByArtistId` (As returned by [`getOpenSubsonicExtensions`](../../endpoints/getopensubsonicextensions))
+
+When a server supports this extension it accepts the `id` parameter of the [`getTopSongs`](../../endpoints/gettopsongs) endpoint, allowing clients to look up top songs by artist ID instead of by name.
+
+## Version 1
+
+You can now request top songs by passing an artist `id` to [`getTopSongs`](../../endpoints/gettopsongs), avoiding the ambiguity of matching by artist name.
+
+This extension requires the support of the `id` parameter of the [`getTopSongs`](../../endpoints/gettopsongs) endpoint. When provided, `id` takes precedence over `artist`.

--- a/openapi/endpoints/getTopSongs.json
+++ b/openapi/endpoints/getTopSongs.json
@@ -8,10 +8,19 @@
         ],
         "parameters": [
             {
+                "name": "artist",
+                "in": "query",
+                "description": "The artist name. Required unless the artist `id` is provided (see the `topSongsByArtistId` extension).",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
                 "name": "id",
                 "in": "query",
-                "description": "The artist name.",
-                "required": true,
+                "description": "The artist ID. Requires OpenSubsonic extension `topSongsByArtistId`. Takes precedence over `artist` when both are provided.",
+                "required": false,
                 "schema": {
                     "type": "string"
                 }
@@ -59,8 +68,12 @@
                     "schema": {
                         "type": "object",
                         "properties": {
+                            "artist": {
+                                "description": "The artist name. Required unless the artist `id` is provided (see the `topSongsByArtistId` extension).",
+                                "type": "string"
+                            },
                             "id": {
-                                "description": "The artist name.",
+                                "description": "The artist ID. Requires OpenSubsonic extension `topSongsByArtistId`. Takes precedence over `artist` when both are provided.",
                                 "type": "string"
                             },
                             "count": {
@@ -69,10 +82,7 @@
                                 "default": 50,
                                 "minimum": 0
                             }
-                        },
-                        "required": [
-                            "id"
-                        ]
+                        }
                     }
                 }
             }


### PR DESCRIPTION
`getTopSongs` currently only accepts an artist **name**. Which is ambiguous since two
artists can share the same name, so the server has to guess which one the client
meant

Passing an artist **ID** removes the ambiguity 

- A server backed by something like ListenBrainz (MBID based) can resolve the
  exact artist directly, disambiguating same named artists
- Even a string-based backend like last.fm benefits. The server can resolve the
  artist from the ID it already knows, then fetch/filter that artist's top songs
  precisely instead of round-tripping a name
