### PR TITLE
feat: add public image url extension

### DIFF
--- a/content/en/docs/Endpoints/getpublicimageurl.md
+++ b/content/en/docs/Endpoints/getpublicimageurl.md
@@ -1,0 +1,56 @@
+---
+title: "getPublicImageURL"
+linkTitle: "getPublicImageURL [OS]"
+opensubsonic:
+- Addition
+categories:
+- Media retrieval
+description: >
+  Returns a URL for accessing cover art publicly.
+---
+
+`http://your-server/rest/getPublicImageURL`
+
+Returns a cover art image.
+
+### Parameters
+
+| Parameter | Req.    | OpenS. | Default | Comment |
+| --------- | ------- | ------ | ------- | --- |
+| `id`      | **Yes** |        | The coverArt ID. Returned by most entities likes [`Child`](../../responses/child) or [`AlbumID3`](../../responses/albumid3) | |
+| `size`    | No      |        | If specified, scale image to this size. | |
+
+
+### Example
+
+{{< alert color="primary" >}} `http://your-server/rest/getPublicImageURL.view?id=123&u=demo&p=demo&v=1.13.0&c=AwesomeClientName&f=json` {{< /alert >}}
+
+### Result
+
+A [`subsonic-response`](../../responses/subsonic-response) element with a nested [`PublicImage`](../../responses/publicImage) element on success.
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic" lang="json">}}
+{
+  "subsonic-response": {
+    "status": "ok",
+    "version": "1.16.1",
+    "type": "AwesomeServerName",
+    "serverVersion": "0.1.3 (tag)",
+    "openSubsonic": true,
+    "publicImage": {
+      "url": "https://your-server/public/image-123",
+      "expiresAt": "2027-01-01T02:19:35.784818075Z"
+    }
+  }
+}
+{{< /tab >}}
+{{< tab header="Subsonic" >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+| Field |  Type | Req. | OpenS. | Details |
+| --- | --- | --- | --- | --- |
+| `publicImage` | [`PublicImage`](../../responses/publicimage) | **Yes** |     | The public image URL and expiration, if specified |

--- a/content/en/docs/Extensions/publicImageUrl.md
+++ b/content/en/docs/Extensions/publicImageUrl.md
@@ -1,0 +1,21 @@
+---
+title: "Public Image URL"
+linkTitle: "Public Image URL"
+OpenSubsonic:
+  - Extension
+description: >
+  Adds support for retrieving a public image URL for items
+---
+
+**OpenSubsonic version**: [1](../../opensubsonic-versions)
+
+**OpenSubsonic extension name**: `publicImageURL` (As returned by [`getOpenSubsonicExtensions`](../../endpoints/getopensubsonicextensions))
+
+## Version 1
+
+This extension provides a way for clients to request a public image URL.
+Unlike [`getcoverart`](../../endpoints/getcoverart), the image returned here **must not require Subsonic authentication tokens**.
+
+This extension requires the following endpoint:
+
+- [`getPublicImageURL`](../../endpoints/getpublicimage): Returns a URL with a possible expiration that can be used to retrieve the image

--- a/content/en/docs/Responses/PublicImage.md
+++ b/content/en/docs/Responses/PublicImage.md
@@ -1,0 +1,29 @@
+---
+title: "PublicImage"
+linkTitle: "PublicImage [OS]"
+OpenSubsonic:
+  - Extension
+description: >
+  Image URL for use externally, with an optional expiration
+---
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic" lang="json">}}
+{
+  "url": "https://your-server/public/image-123",
+  "expiresAt": "2027-01-01T02:19:35.784818075Z"
+}
+{{< /tab >}}
+{{< tab header="Subsonic">}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+| Field       | Type     | Req.    | OpenS. | Details                                                 |
+| ----------- | -------- | ------- | ------ | ------------------------------------------------------- |
+| `url`       | `long`   | **Yes** |        | A URL which can be used to retrieve the requested image |
+| `expiresAt` | `string` | No      |        | When the URL expires [ISO 8601]                         |
+
+**Note**: The only requirement for the `url` returned by a server is that it **must not** encode user credentials.
+This URL must be safe to be shared publicly.

--- a/openapi/endpoints/getPublicImageURL.json
+++ b/openapi/endpoints/getPublicImageURL.json
@@ -1,0 +1,89 @@
+{
+    "get": {
+        "summary": "Returns a URL for accessing cover art publicly.",
+        "operationId": "getPublicImageURL",
+        "tags": ["Media Retrieval"],
+        "parameters": [
+            {
+                "name": "id",
+                "in": "query",
+                "description": "The coverArt ID. Returned by most entities likes `Child` or `AlbumID3`",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "name": "size",
+                "in": "query",
+                "description": "If specified, scale image to this size.",
+                "required": false,
+                "schema": {
+                    "type": "integer"
+                }
+            }
+        ],
+        "responses": {
+            "200": {
+                "description": "Successful or failed response",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "./getPublicImageURL/GetPublicImageUrlResponse.json"
+                        }
+                    }
+                }
+            }
+        },
+        "externalDocs": {
+            "description": "getPublicImageURL",
+            "url": "https://opensubsonic.netlify.app/docs/endpoints/getpublicimageurl/"
+        }
+    },
+    "post": {
+        "summary": "Returns a URL for accessing cover art publicly.",
+        "operationId": "postGetPublicImageURL",
+        "tags": ["Media Retrieval"],
+        "requestBody": {
+            "required": true,
+            "content": {
+                "application/x-www-form-urlencoded": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "id": {
+                                "type": "string",
+                                "description": "The coverArt ID. Returned by most entities likes `Child` or `AlbumID3`"
+                            },
+                            "size": {
+                                "type": "integer",
+                                "description": "If specified, scale image to this size."
+                            }
+                        },
+                        "required": ["id"]
+                    }
+                }
+            }
+        },
+        "parameters": [],
+        "responses": {
+            "200": {
+                "description": "Successful or failed response",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "./getPublicImageURL/GetPublicImageUrlResponse.json"
+                        }
+                    }
+                }
+            },
+            "405": {
+                "$ref": "../responses/HTTPFormPostNotSupported.json"
+            }
+        },
+        "externalDocs": {
+            "description": "getPublicImageURL",
+            "url": "https://opensubsonic.netlify.app/docs/endpoints/getpublicimageurl/"
+        }
+    }
+}

--- a/openapi/endpoints/getPublicImageURL/GetPublicImageUrlResponse.json
+++ b/openapi/endpoints/getPublicImageURL/GetPublicImageUrlResponse.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "description": "A subsonic-response element with a nested `PublicImage` element on success.",
+    "properties": {
+        "subsonic-response": {
+            "oneOf": [
+                {
+                    "$ref": "./GetPublicImageUrlSuccessResponse.json"
+                },
+                {
+                    "$ref": "../../schemas/SubsonicResponse/SubsonicFailureResponse.json"
+                }
+            ]
+        }
+    },
+    "externalDocs": {
+        "description": "GetPublicImageURL",
+        "url": "https://opensubsonic.netlify.app/docs/endpoints/getPublicImageURL/"
+    }
+}

--- a/openapi/endpoints/getPublicImageURL/GetPublicImageUrlSuccessResponse.json
+++ b/openapi/endpoints/getPublicImageURL/GetPublicImageUrlSuccessResponse.json
@@ -1,0 +1,16 @@
+{
+    "allOf": [
+        {
+            "$ref": "../../schemas/SubsonicResponse/SubsonicSuccessResponse.json"
+        },
+        {
+            "type": "object",
+            "properties": {
+                "publicImage": {
+                    "$ref": "../../schemas/PublicImage.json"
+                }
+            },
+            "required": ["publicImage"]
+        }
+    ]
+}

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -255,6 +255,9 @@
         "/rest/getPodcasts": {
             "$ref": "./endpoints/getPodcasts.json"
         },
+        "/rest/getPublicImageURL": {
+            "$ref": "./endpoints/getPublicImageURL.json"
+        },
         "/rest/getRandomSongs": {
             "$ref": "./endpoints/getRandomSongs.json"
         },

--- a/openapi/schemas/PublicImage.json
+++ b/openapi/schemas/PublicImage.json
@@ -1,0 +1,20 @@
+{
+    "type": "object",
+    "description": "A public image.",
+    "externalDocs": {
+        "description": "PublicImage",
+        "url": "https://opensubsonic.netlify.app/docs/responses/publicimage/"
+    },
+    "properties": {
+        "url": {
+            "type": "string",
+            "description": "Public image URL"
+        },
+        "expiresAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this URL expires"
+        }
+    },
+    "required": ["url"]
+}


### PR DESCRIPTION
For clients, `getCoverArt` is completely unsuitable for sharing publicly (e.g., for discord rpc). This extension provides a way to convert a request for `/rest/getCoverArt` to a URL that could be shared publicly.