### PR TITLE
feat(songLyrics v2): add explicit line end timing

### DIFF
--- a/content/en/docs/Endpoints/getLyricsBySongId.md
+++ b/content/en/docs/Endpoints/getLyricsBySongId.md
@@ -123,7 +123,7 @@ Does not exist.
 
 #### Version 2 (`enhanced=true`)
 
-When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
+When `enhanced=true` is passed, the response includes `kind` to classify lyric tracks, optional exact `line.end` timing, [`cueLine`](../../responses/cueline) arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, optional per-entry [`agents`](../../responses/agent) metadata for agent attribution, and additional tracks such as translations and pronunciations.
 
 {{< alert color="primary" >}} `http://your-server/rest/getLyricsBySongId.view?id=456&enhanced=true&u=demo&p=demo&v=1.13.0&c=AwesomeClientName&f=json` {{< /alert >}}
 
@@ -144,8 +144,8 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
           "lang": "ko",
           "synced": true,
           "line": [
-            { "start": 2747, "value": "눈을 뜬 순간" },
-            { "start": 6214, "value": "모든 게 달라졌어" }
+            { "start": 2747, "end": 6214, "value": "눈을 뜬 순간" },
+            { "start": 6214, "end": 9000, "value": "모든 게 달라졌어" }
           ],
           "cueLine": [
             {
@@ -230,8 +230,8 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
 <subsonic-response status="ok" version="1.16.1" type="AwesomeServerName" serverVersion="0.1.3 (tag)" openSubsonic="true">
   <lyricsList>
     <structuredLyrics kind="main" lang="ko" synced="true">
-      <line start="2747">눈을 뜬 순간</line>
-      <line start="6214">모든 게 달라졌어</line>
+      <line start="2747" end="6214">눈을 뜬 순간</line>
+      <line start="6214" end="9000">모든 게 달라졌어</line>
       <cueLine index="0" start="2747" end="6214" value="눈을 뜬 순간">
         <cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
         <cue start="3018" end="3179" byteStart="3" byteEnd="5">을</cue>
@@ -270,6 +270,33 @@ When `enhanced=true` is passed, the response includes `kind` to classify lyric t
     </structuredLyrics>
   </lyricsList>
 </subsonic-response>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+##### Explicit line-end timing
+
+In a version 2 enhanced response, `line.end` uses the same track-relative millisecond timeline as `line.start`. It is exact timing when known and is never inferred from the next line. The field may be present independently per line, including on the final line. Gaps, overlaps, and zero-duration markers are valid:
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
+{
+  "line": [
+    { "start": 0, "end": 1800, "value": "An explicit gap follows" },
+    { "start": 2000, "end": 3500, "value": "This line overlaps the next" },
+    { "start": 3200, "end": 3200, "value": "Instantaneous marker" },
+    { "start": 5000, "end": 6400, "value": "The final line has an explicit end" }
+  ]
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
+<line start="0" end="1800">An explicit gap follows</line>
+<line start="2000" end="3500">This line overlaps the next</line>
+<line start="3200" end="3200">Instantaneous marker</line>
+<line start="5000" end="6400">The final line has an explicit end</line>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
 Does not exist.
@@ -465,7 +492,7 @@ Without `enhanced=true`, the response is identical to version 1:
 
 - Only `kind="main"` entries are returned (the `kind` field itself is omitted)
 - No `cueLine` arrays are included
-- The existing `line` array is always present and unchanged
+- The existing `line` array is always present and unchanged, with no `end` fields
 - `cueLine` is a **parallel** structure, not a replacement for `line`
 
 Servers that don't support TTML or word-level timing simply never include these fields. Clients that don't support karaoke display simply ignore them.

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -37,7 +37,7 @@ When agent attribution is present, the reusable agent metadata lives once in `st
 
 Each cue includes `byteStart` / `byteEnd`, defined as 0-based inclusive offsets into the UTF-8 encoding of the final `cueLine.value`, with no normalization step. Accordingly, each `cueLine` that contains cues must also include `value`. When multiple agent cueLines share one parent line index, each `cueLine.value` is the renderable text for that agent/layer, not necessarily the parent line's combined text.
 
-`line.end` uses the same track-relative millisecond timeline as `line.start`. When present, `start` **must** also be present and `end` **must** be greater than or equal to `start`. A zero-duration line (`end == start`) is a valid instantaneous marker. Lines may overlap or leave gaps, and omission means the exact end is unknown; clients **must not** infer it from the next line. The optional `structuredLyrics.offset` applies equally to both timestamps. Unsynced lyrics **must** omit both fields.
+`line.end` uses the same track-relative millisecond timeline as `line.start`. When present, `start` **must** also be present and `end` **must** be greater than or equal to `start`. A zero-duration line (`end == start`) is a valid instantaneous marker. Lines may overlap or leave gaps. When `end` is omitted, clients may infer a fallback end, for example from the next line's start, but should not treat it as exact source timing. The optional `structuredLyrics.offset` applies equally to both timestamps. Unsynced lyrics **must** omit both fields.
 
 All new fields are gated behind `enhanced=true` — without it, the response is identical to version 1.
 

--- a/content/en/docs/Extensions/songLyrics.md
+++ b/content/en/docs/Extensions/songLyrics.md
@@ -31,10 +31,13 @@ Adds:
 - [`cueLine`](../../responses/cueline) array on [`structuredLyrics`](../../responses/structuredlyrics) for word/syllable-level timing
 - `agentId` field on [`cueLine`](../../responses/cueline) to reference an [`agent`](../../responses/agent) in the same `structuredLyrics` entry
 - [`cue`](../../responses/cue) objects within each `cueLine` for individual word/syllable timestamps, with required `byteStart` / `byteEnd` offsets into `cueLine.value`
+- optional `end` timing on [`line`](../../responses/line) when the exact line end is known
 
 When agent attribution is present, the reusable agent metadata lives once in `structuredLyrics.agents`, while each `cueLine` points at the relevant agent via `agentId`. Simple unattributed single-layer lyrics may omit `agents` entirely. Entries with multiple vocal agents/layers **must** emit `agents`, and every attributed entry that uses `agents` **must** define exactly one `role: "main"` agent. A single-agent attributed/default layer may also use `agents` with that lone agent marked as `main`.
 
 Each cue includes `byteStart` / `byteEnd`, defined as 0-based inclusive offsets into the UTF-8 encoding of the final `cueLine.value`, with no normalization step. Accordingly, each `cueLine` that contains cues must also include `value`. When multiple agent cueLines share one parent line index, each `cueLine.value` is the renderable text for that agent/layer, not necessarily the parent line's combined text.
+
+`line.end` uses the same track-relative millisecond timeline as `line.start`. When present, `start` **must** also be present and `end` **must** be greater than or equal to `start`. A zero-duration line (`end == start`) is a valid instantaneous marker. Lines may overlap or leave gaps, and omission means the exact end is unknown; clients **must not** infer it from the next line. The optional `structuredLyrics.offset` applies equally to both timestamps. Unsynced lyrics **must** omit both fields.
 
 All new fields are gated behind `enhanced=true` — without it, the response is identical to version 1.
 

--- a/content/en/docs/Responses/line.md
+++ b/content/en/docs/Responses/line.md
@@ -29,7 +29,7 @@ Does not exist.
 | `start` | `number` | No      | **Yes** | The start time of the lyrics, relative to the start time of the track, in milliseconds. If this is not part of synced lyrics, `start` **must** be omitted                                                                                                     |
 | `end`   | `number` | No      | **Yes** | The exact end time on the same timeline as `start`, in milliseconds. When present, `start` **must** also be present and `end` **must** be greater than or equal to `start`. Only returned by [`songLyrics`](../../extensions/songlyrics) version 2 with `enhanced=true` |
 
-`end` is optional independently for each line. Its omission means the end is unknown; clients **must not** assume the line lasts until the next line starts. Gaps and overlapping lines are valid, as is `end == start` for an instantaneous marker. Unsynced lyrics **must** omit both `start` and `end`.
+`end` is optional independently for each line. Its omission means the exact end is unknown. Clients may infer a fallback end, for example from the next line's start, but should not treat it as exact source timing. Gaps and overlapping lines are valid, as is `end == start` for an instantaneous marker. Unsynced lyrics **must** omit both `start` and `end`.
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type.

--- a/content/en/docs/Responses/line.md
+++ b/content/en/docs/Responses/line.md
@@ -23,10 +23,13 @@ Does not exist.
 {{< /tab >}}
 {{< /tabpane >}}
 
-| Field   | Type     | Req.    | OpenS.  | Details                                                                                                                                                 |
-| ------- | -------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `value` | `string` | **Yes** | **Yes** | The actual text of this line                                                                                                                            |
-| `start` | `number` | No      | **Yes** | The start time of the lyrics, relative to the start time of the track, in milliseconds. If this is not part of synced lyrics, start **must** be omitted |
+| Field   | Type     | Req.    | OpenS.  | Details                                                                                                                                                                                                                                                       |
+| ------- | -------- | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `value` | `string` | **Yes** | **Yes** | The actual text of this line                                                                                                                                                                                                                                  |
+| `start` | `number` | No      | **Yes** | The start time of the lyrics, relative to the start time of the track, in milliseconds. If this is not part of synced lyrics, `start` **must** be omitted                                                                                                     |
+| `end`   | `number` | No      | **Yes** | The exact end time on the same timeline as `start`, in milliseconds. When present, `start` **must** also be present and `end` **must** be greater than or equal to `start`. Only returned by [`songLyrics`](../../extensions/songlyrics) version 2 with `enhanced=true` |
+
+`end` is optional independently for each line. Its omission means the end is unknown; clients **must not** assume the line lasts until the next line starts. Gaps and overlapping lines are valid, as is `end == start` for an instantaneous marker. Unsynced lyrics **must** omit both `start` and `end`.
 
 {{< alert color="warning" title="OpenSubsonic" >}}
 This is a new OpenSubsonic response type.

--- a/content/en/docs/Responses/structuredLyrics.md
+++ b/content/en/docs/Responses/structuredLyrics.md
@@ -48,7 +48,7 @@ Does not exist.
 
 ### Version 2 (enhanced — word/syllable-level with kind)
 
-When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, `cueLine` arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and optional `agents` arrays for reusable agent attribution.
+When `enhanced=true` is passed to [`getLyricsBySongId`](../../endpoints/getlyricsbysongid), the response includes additional fields: `kind` to classify lyric tracks, optional exact `line.end` timing, `cueLine` arrays with word/syllable-level timing, cue `byteStart` / `byteEnd` offsets into `cueLine.value`, and optional `agents` arrays for reusable agent attribution.
 
 Each `structuredLyrics` entry is self-contained. Clients should treat tracks with different `kind` values, including `main`, as independent layers rather than assuming 1:1 line or cue alignment between them. Agent identity is also scoped to a single `structuredLyrics` entry; `agents[].id` values have no meaning outside that entry. When a cue uses `byteStart` / `byteEnd`, those offsets are always relative to the final `cueLine.value` string in the same entry.
 
@@ -60,8 +60,8 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
   "lang": "ko",
   "synced": true,
   "line": [
-    { "start": 2747, "value": "눈을 뜬 순간" },
-    { "start": 6214, "value": "모든 게 달라졌어" }
+    { "start": 2747, "end": 6214, "value": "눈을 뜬 순간" },
+    { "start": 6214, "end": 9000, "value": "모든 게 달라졌어" }
   ],
   "cueLine": [
     {
@@ -98,8 +98,8 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
 {{< /tab >}}
 {{< tab header="OpenSubsonic XML" lang="xml">}}
 <structuredLyrics kind="main" lang="ko" synced="true">
-  <line start="2747">눈을 뜬 순간</line>
-  <line start="6214">모든 게 달라졌어</line>
+  <line start="2747" end="6214">눈을 뜬 순간</line>
+  <line start="6214" end="9000">모든 게 달라졌어</line>
   <cueLine index="0" start="2747" end="6214" value="눈을 뜬 순간">
     <cue start="2747" end="3018" byteStart="0" byteEnd="2">눈</cue>
     <cue start="3018" end="3179" byteStart="3" byteEnd="5">을</cue>
@@ -117,6 +117,37 @@ Each `structuredLyrics` entry is self-contained. Clients should treat tracks wit
     <cue start="8000" end="8400" byteStart="10" byteEnd="10"> </cue>
     <cue start="8400" end="9000" byteStart="11" byteEnd="22">달라졌어</cue>
   </cueLine>
+</structuredLyrics>
+{{< /tab >}}
+{{< tab header="Subsonic"  >}}
+Does not exist.
+{{< /tab >}}
+{{< /tabpane >}}
+
+#### Explicit line-end behavior
+
+`line.end` is exact timing when known; it is not inferred from the next line. It may be present independently per line, including on the final line. Gaps, overlaps, and zero-duration markers are all valid:
+
+{{< tabpane persist=false >}}
+{{< tab header="**Example**:" disabled=true />}}
+{{< tab header="OpenSubsonic JSON" lang="json">}}
+{
+  "lang": "eng",
+  "synced": true,
+  "line": [
+    { "start": 0, "end": 1800, "value": "An explicit gap follows" },
+    { "start": 2000, "end": 3500, "value": "This line overlaps the next" },
+    { "start": 3200, "end": 3200, "value": "Instantaneous marker" },
+    { "start": 5000, "end": 6400, "value": "The final line has an explicit end" }
+  ]
+}
+{{< /tab >}}
+{{< tab header="OpenSubsonic XML" lang="xml">}}
+<structuredLyrics lang="eng" synced="true">
+  <line start="0" end="1800">An explicit gap follows</line>
+  <line start="2000" end="3500">This line overlaps the next</line>
+  <line start="3200" end="3200">Instantaneous marker</line>
+  <line start="5000" end="6400">The final line has an explicit end</line>
 </structuredLyrics>
 {{< /tab >}}
 {{< tab header="Subsonic"  >}}
@@ -288,7 +319,7 @@ Does not exist.
 | `line`          | Array of [`line`](../line)           | **Yes** | **Yes** | The actual lyrics. Ordered by start time (synced) or appearance order (unsynced)                                                                                                                                                                                                                                                                |
 | `displayArtist` | `string`                             | No      | **Yes** | The artist name to display. This could be the localized name, or any other value                                                                                                                                                                                                                                                                |
 | `displayTitle`  | `string`                             | No      | **Yes** | The title to display. This could be the song title (localized), or any other value                                                                                                                                                                                                                                                              |
-| `offset`        | `number`                             | No      | **Yes** | The offset to apply to all lyrics, in milliseconds. Positive means lyrics appear sooner, negative means later. If not included, the offset **must** be assumed to be 0                                                                                                                                                                         |
+| `offset`        | `number`                             | No      | **Yes** | The offset to apply to all lyric timing, in milliseconds, including both `line.start` and `line.end`. Positive means lyrics appear sooner, negative means later. If not included, the offset **must** be assumed to be 0                                                                                                                          |
 | `kind`          | `string`                             | No      | **Yes** | The primary lyric-layer classification for this `structuredLyrics` entry. One of: `main` (primary vocals for this entry, default if omitted), `translation` (a translation of another lyric layer into another language), `pronunciation` (a phonetic/romanized rendering, e.g. romaji for Japanese, pinyin for Chinese). Tracks are independent across `kind` values; clients should not assume 1:1 line or cue alignment between entries. Only returned when `enhanced=true`. Added in [`songLyrics`](../../extensions/songlyrics) version 2 |
 | `agents`        | Array of [`agent`](../agent)         | No      | **Yes** | Reusable per-track attribution metadata for `cueLine` entries. When present, **must** contain at least one entry, and each `agents[].id` **must** be unique within this `structuredLyrics` entry. `agents` are optional for simple unattributed single-layer lyrics. When a `structuredLyrics` entry represents multiple vocal agents/layers, it **must** include `agents`; a single-agent attributed/default entry may also include `agents`, and if it does, exactly one agent **must** use `role: "main"`. `agents` should not be emitted without `cueLine` data |
 | `cueLine`       | Array of [`cueLine`](../cueline)     | No      | **Yes** | Word/syllable-level timing data. Each cueLine corresponds to a `line` by its `index` field. Every cueLine **must** include `value`, and every nested cue **must** include `byteStart` / `byteEnd` offsets into that exact string. If `agents` is present, every cueLine in the entry **must** include `agentId`; if `agents` is absent, cueLines **must not** include `agentId`. Only returned when `enhanced=true` and `synced` is `true`. Added in [`songLyrics`](../../extensions/songlyrics) version 2 |

--- a/openapi/schemas/Line.json
+++ b/openapi/schemas/Line.json
@@ -13,6 +13,10 @@
         "start": {
             "type": "number",
             "description": "The start time of the lyrics, relative to the start time of the track, in milliseconds. If this is not part of synced lyrics, start __must__ be omitted"
+        },
+        "end": {
+            "type": "number",
+            "description": "The optional exact end time of the lyrics on the same track-relative millisecond timeline as start. It is only returned for songLyrics version 2 enhanced responses. When present, start must also be present and end must be greater than or equal to start. If this is not part of synced lyrics, end must be omitted"
         }
     },
     "required": [


### PR DESCRIPTION
## Summary

`line.start` tells a client when a lyric line begins, but it cannot describe when the final line ends or distinguish a deliberate gap, an overlap, and an instantaneous marker. This adds an optional `line.end` value so enhanced lyrics clients can represent those timings without inferring them from the next line.

## Compatibility

- `end` uses the same track-relative millisecond timeline as `start`; the structured-lyrics offset applies to both values.
- It requires `start`, must be greater than or equal to it, and may equal it for an instantaneous marker. Gaps and overlaps remain valid.
- An omitted `end` means that the end is unknown. It does not imply the next line's start.
- The field is available only in `enhanced=true` responses. Unsynced lyrics omit both timing values, while default responses and the advertised `[1, 2]` versions remain unchanged.
