### PR TITLE
command to bundle split spec into one file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ resources/
 node_modules/
 .hugo_build.lock
 content/en/docs/Openapi/openapi.json
+openapi-opensubsonic.json

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "start": "npx hugo server",
     "build": "markdownlint 'content/**/*.md' --config .markdownlint.json && npm run build:openapi && npx hugo --gc --minify",
     "build:openapi": "swagger-cli bundle openapi/openapi.json -o content/en/docs/Openapi/openapi.json --type json && npx vacuum lint content/en/docs/Openapi/openapi.json -d -a -e",
+    "bundle:openapi": "swagger-cli bundle openapi/openapi.json -o openapi-opensubsonic.json --type json && npx vacuum lint openapi-opensubsonic.json -d -a -e",
     "lint:md": "markdownlint 'content/**/*.md' --config .markdownlint.json"
   },
   "repository": {


### PR DESCRIPTION
This lets you run an npm command to bundle up the spec file.

This lets me (and others) generate a full spec for testing / copying etc